### PR TITLE
Convert `MessageRouter` to an interface

### DIFF
--- a/pipeline/config.go
+++ b/pipeline/config.go
@@ -44,7 +44,7 @@ type PluginConfig map[string]toml.Primitive
 type PluginHelper interface {
 	PackSupply() chan *PipelinePack
 	Output(name string) (oRunner OutputRunner, ok bool)
-	Router() (router *MessageRouter)
+	Router() (router MessageRouter)
 	Filter(name string) (fRunner FilterRunner, ok bool)
 	PipelineConfig() *PipelineConfig
 	DecoderSet() DecoderSet
@@ -63,7 +63,7 @@ type PipelineConfig struct {
 	DecoderSets     []DecoderSet
 	FilterRunners   map[string]FilterRunner
 	OutputRunners   map[string]OutputRunner
-	router          *MessageRouter
+	router          *messageRouter
 	RecycleChan     chan *PipelinePack
 	logMsgs         []string
 	filtersLock     sync.Mutex
@@ -104,7 +104,7 @@ func (self *PipelineConfig) Output(name string) (oRunner OutputRunner, ok bool) 
 	return
 }
 
-func (self *PipelineConfig) Router() (router *MessageRouter) {
+func (self *PipelineConfig) Router() (router MessageRouter) {
 	return self.router
 }
 
@@ -136,7 +136,7 @@ func (self *PipelineConfig) AddFilterRunner(fRunner FilterRunner) error {
 		return fmt.Errorf("AddFilterRunner '%s' failed to start: %s",
 			fRunner.Name(), err)
 	} else {
-		self.router.MrChan <- fRunner.MatchRunner()
+		self.router.MrChan() <- fRunner.MatchRunner()
 	}
 	return nil
 }
@@ -146,7 +146,7 @@ func (self *PipelineConfig) RemoveFilterRunner(name string) bool {
 	self.filtersLock.Lock()
 	defer self.filtersLock.Unlock()
 	if fRunner, ok := self.FilterRunners[name]; ok {
-		self.router.MrChan <- fRunner.MatchRunner()
+		self.router.MrChan() <- fRunner.MatchRunner()
 		close(fRunner.InChan())
 		delete(self.FilterRunners, name)
 		return true

--- a/pipeline/decoders.go
+++ b/pipeline/decoders.go
@@ -145,7 +145,7 @@ func (dr *dRunner) Start(h PluginHelper, wg *sync.WaitGroup) {
 				continue
 			}
 			pack.Decoded = true
-			h.Router().InChan <- pack
+			h.Router().InChan() <- pack
 		}
 		dr.LogMessage("stopped")
 		wg.Done()

--- a/pipeline/inputs.go
+++ b/pipeline/inputs.go
@@ -481,7 +481,7 @@ func (self *MessageGeneratorInput) Run(ir InputRunner, h PluginHelper) (err erro
 	var outMsg outputMsg
 	var output OutputRunner
 	ok := true
-	outChan := h.Router().InChan
+	outChan := h.Router().InChan()
 
 	for ok {
 		output = nil

--- a/pipeline/logfile_input.go
+++ b/pipeline/logfile_input.go
@@ -87,7 +87,7 @@ func (lw *LogfileInput) LineReader(ir InputRunner, h PluginHelper,
 				break
 			}
 		}
-		h.Router().InChan <- pack
+		h.Router().InChan() <- pack
 	}
 
 	log.Println("Input stopped: LogfileInput")

--- a/pipeline/mock_pluginhelper_test.go
+++ b/pipeline/mock_pluginhelper_test.go
@@ -80,9 +80,9 @@ func (_mr *_MockPluginHelperRecorder) PipelineConfig() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PipelineConfig")
 }
 
-func (_m *MockPluginHelper) Router() *MessageRouter {
+func (_m *MockPluginHelper) Router() MessageRouter {
 	ret := _m.ctrl.Call(_m, "Router")
-	ret0, _ := ret[0].(*MessageRouter)
+	ret0, _ := ret[0].(MessageRouter)
 	return ret0
 }
 

--- a/pipeline/pipeline_runner.go
+++ b/pipeline/pipeline_runner.go
@@ -263,7 +263,7 @@ func Run(config *PipelineConfig) {
 		config.RecycleChan <- NewPipelinePack(config.RecycleChan)
 	}
 
-	config.Router().Start()
+	config.router.Start()
 
 	for name, input := range config.InputRunners {
 		// Special case the MGI, it shuts down last.

--- a/pipeline/report.go
+++ b/pipeline/report.go
@@ -93,8 +93,8 @@ func (pc *PipelineConfig) reports(reportChan chan *PipelinePack) {
 
 	pack = MessageGenerator.Retrieve()
 	msg = pack.Message
-	newIntField(msg, "InChanCapacity", cap(pc.Router().InChan))
-	newIntField(msg, "InChanLength", len(pc.Router().InChan))
+	newIntField(msg, "InChanCapacity", cap(pc.Router().InChan()))
+	newIntField(msg, "InChanLength", len(pc.Router().InChan()))
 	msg.SetType("heka.router-report")
 	setNameField(msg, "Router")
 	reportChan <- pack

--- a/pipeline/router.go
+++ b/pipeline/router.go
@@ -23,24 +23,38 @@ import (
 	"sync/atomic"
 )
 
-// Pushes the message onto the filters input channel if it is a match
-type MessageRouter struct {
-	InChan    chan *PipelinePack
-	MrChan    chan *MatchRunner
+type MessageRouter interface {
+	InChan() chan *PipelinePack
+	MrChan() chan *MatchRunner
+}
+
+// Pushes the message onto the input channel for every filter and output
+// plugin that is a match
+type messageRouter struct {
+	inChan    chan *PipelinePack
+	mrChan    chan *MatchRunner
 	fMatchers []*MatchRunner
 	oMatchers []*MatchRunner
 }
 
-func NewMessageRouter() (router *MessageRouter) {
-	router = new(MessageRouter)
-	router.InChan = make(chan *PipelinePack, Globals().PluginChanSize)
-	router.MrChan = make(chan *MatchRunner, 0)
+func NewMessageRouter() (router *messageRouter) {
+	router = new(messageRouter)
+	router.inChan = make(chan *PipelinePack, Globals().PluginChanSize)
+	router.mrChan = make(chan *MatchRunner, 0)
 	router.fMatchers = make([]*MatchRunner, 0, 10)
 	router.oMatchers = make([]*MatchRunner, 0, 10)
 	return router
 }
 
-func (self *MessageRouter) Start() {
+func (self *messageRouter) InChan() chan *PipelinePack {
+	return self.inChan
+}
+
+func (self *messageRouter) MrChan() chan *MatchRunner {
+	return self.mrChan
+}
+
+func (self *messageRouter) Start() {
 	go func() {
 		var matcher *MatchRunner
 		var ok = true
@@ -48,7 +62,7 @@ func (self *MessageRouter) Start() {
 		for ok {
 			runtime.Gosched()
 			select {
-			case matcher = <-self.MrChan:
+			case matcher = <-self.mrChan:
 				if matcher != nil {
 					removed := false
 					available := -1
@@ -71,7 +85,7 @@ func (self *MessageRouter) Start() {
 						}
 					}
 				}
-			case pack, ok = <-self.InChan:
+			case pack, ok = <-self.inChan:
 				if !ok {
 					break
 				}


### PR DESCRIPTION
Convert `MessageRouter` to an interface so we have parity w/ the other APIs and so we're not so tied to the implementation.
