### PR TITLE
Allow the input channel to start draining immediately on termination

### DIFF
--- a/pipeline/sandbox_filter.go
+++ b/pipeline/sandbox_filter.go
@@ -213,7 +213,7 @@ func (this *SandboxFilter) Run(fr FilterRunner, h PluginHelper) (err error) {
 	}
 
 	if terminated {
-		h.PipelineConfig().RemoveFilterRunner(fr.Name())
+		go h.PipelineConfig().RemoveFilterRunner(fr.Name())
 		// recycle any messages until the matcher is torn down
 		for plc = range inChan {
 			plc.Pack.Recycle()


### PR DESCRIPTION
If the mis-behaving sandbox is holding the entire message pool
the system will deadlock
