### PR TITLE
Issue #200 #150 #149 Reporting/Self Monitoring

### DIFF
--- a/cmd/sbmgr/hekad.toml.sbmgr
+++ b/cmd/sbmgr/hekad.toml.sbmgr
@@ -58,6 +58,17 @@ memory_limit = 256000
 instruction_limit = 1000
 output_limit = 64000
 
+[SlowMatcher]
+type = "SandboxFilter"
+message_matcher = "(Type == 'heka.sandbox-output' && Fields[payload_type] == 'nagios-external-command' && Fields[payload_name] == 'PROCESS_SERVICE_CHECK_RESULT') || (Type =~ /(hekabench)/ && Hostname =~ /(.*)/ && Uuid =~ /([a-z0-9]{8}-[a-z0-9]{4}-4[a-z0-9]{3}-[a-z0-9]{4}-[a-z0-9]{12})/ && Payload =~ /(.*)/ && Type =~ /(?P<one>hekabench)/ && Hostname =~ /(?P<two>.*)/ && Uuid =~ /(?P<three>[a-z0-9]{8}-[a-z0-9]{4}-4[a-z0-9]{3}-[a-z0-9]{4}-[a-z0-9]{12})/ && Payload =~ /(?P<four>.*)/)"
+ticker_interval = 1
+script_type = "lua"
+filename = "../src/github.com/mozilla-services/heka/sandbox/lua/testsupport/hekabench_cbuf_counter.lua"
+preserve_data = false
+memory_limit = 256000
+instruction_limit = 1000
+output_limit = 64000
+
 [LoopToSelf]
 type = "SandboxFilter"
 message_matcher = "Type == 'hekabench' || (Logger == 'LoopToSelf' && Type != 'heka.sandbox-terminated')"

--- a/pipeline/dashboard_output.go
+++ b/pipeline/dashboard_output.go
@@ -143,7 +143,7 @@ func getReportHtml() string {
     <script src="http://yui.yahooapis.com/3.9.1/build/yui/yui-min.js">
     </script>
 </head>
-<body class="yui3-skin-sam">
+<body class="yui3-skin-sam" style="font-size:.7em">
     <div id="report"></div>
 <script>
 YUI().use("datatable-base", "datasource", "datasource-jsonschema", "datatable-datasource", "datatable-sort", function (Y) {
@@ -157,13 +157,15 @@ dataSource.plug({fn: Y.Plugin.DataSourceJSONSchema, cfg: {
                 'InChanLength',
                 'MatchChanCapacity',
                 'MatchChanLength',
+                'MatcherAvgDuration',
+                'ProcessMessageCount',
+                'InjectMessageCount',
                 'Memory',
                 'MaxMemory',
                 'MaxInstructions',
                 'MaxOutput',
-   			 'ProcessMessageCount',
-   			 'ProcessMessageAvgDuration',
-   			 'TimerEventAvgDuration'
+                'ProcessMessageAvgDuration',
+                'TimerEventAvgDuration'
             ]
         }}
     });
@@ -174,12 +176,14 @@ var table = new Y.DataTable({
               {key: 'InChanLength', sortable:true},
               {key: 'MatchChanCapacity', sortable:true},
               {key: 'MatchChanLength', sortable:true},
+              {key: 'MatcherAvgDuration', sortable:true, label: 'MatcherAvgDuration (ns)'},
+              {key:'ProcessMessageCount', sortable:true, label: 'ProcessedMsgs'},
+              {key:'InjectMessageCount', sortable:true, label: 'InjectedMsgs'},
               {label: 'Sandbox Metrics', children: [
-                {key:'Memory', sortable:true, label: 'Memory (B)'},
-                {key:'MaxMemory', sortable:true, label: 'MaxMemory (B)'},
+                {key:'Memory', sortable:true, label: 'Mem (B)'},
+                {key:'MaxMemory', sortable:true, label: 'MaxMem (B)'},
                 {key:'MaxOutput', sortable:true, label: 'MaxOutput (B)'},
                 {key:'MaxInstructions', sortable:true},
-                {key:'ProcessMessageCount', sortable:true, label: 'Messages'},
                 {key:'ProcessMessageAvgDuration', sortable:true, label: 'AvgProcess (ns)'},
                 {key:'TimerEventAvgDuration', sortable:true, label: 'AvgOutput (ns)'}
               ]}],

--- a/pipeline/report.go
+++ b/pipeline/report.go
@@ -79,6 +79,12 @@ func PopulateReportMsg(pr PluginRunner, msg *message.Message) (err error) {
 		newIntField(msg, "InChanLength", len(fRunner.InChan()))
 		newIntField(msg, "MatchChanCapacity", cap(fRunner.MatchRunner().inChan))
 		newIntField(msg, "MatchChanLength", len(fRunner.MatchRunner().inChan))
+		var tmp int64 = 0
+		if fRunner.MatchRunner().matchSamples > 0 {
+			tmp = fRunner.MatchRunner().matchDuration.Nanoseconds() /
+				fRunner.MatchRunner().matchSamples
+		}
+		newInt64Field(msg, "MatcherAvgDuration", tmp)
 	} else if dRunner, ok := pr.(DecoderRunner); ok {
 		newIntField(msg, "InChanCapacity", cap(dRunner.InChan()))
 		newIntField(msg, "InChanLength", len(dRunner.InChan()))
@@ -117,6 +123,7 @@ func (pc *PipelineConfig) reports(reportChan chan *PipelinePack) {
 	msg = pack.Message
 	newIntField(msg, "InChanCapacity", cap(pc.router.InChan()))
 	newIntField(msg, "InChanLength", len(pc.router.InChan()))
+	newInt64Field(msg, "ProcessMessageCount", pc.router.processMessageCount)
 	msg.SetType("heka.router-report")
 	setNameField(msg, "Router")
 	reportChan <- pack

--- a/pipeline/router.go
+++ b/pipeline/router.go
@@ -18,9 +18,11 @@ package pipeline
 import (
 	"github.com/mozilla-services/heka/message"
 	"log"
+	"math/rand"
 	"runtime"
 	"strings"
 	"sync/atomic"
+	"time"
 )
 
 // Public interface exposed by the Heka message router. The message router
@@ -52,6 +54,7 @@ type messageRouter struct {
 	removeOutputMatcher chan *MatchRunner
 	fMatchers           []*MatchRunner
 	oMatchers           []*MatchRunner
+	processMessageCount int64
 }
 
 // Creates and returns a (not yet started) Heka message router.
@@ -139,6 +142,7 @@ func (self *messageRouter) Start() {
 				if !ok {
 					break
 				}
+				self.processMessageCount++
 				for _, matcher = range self.fMatchers {
 					if matcher != nil {
 						atomic.AddInt32(&pack.RefCount, 1)
@@ -170,9 +174,11 @@ func (self *messageRouter) Start() {
 // Encapsulates the mechanics of testing messages against a specific plugin's
 // message_matcher value.
 type MatchRunner struct {
-	spec   *message.MatcherSpecification
-	signer string
-	inChan chan *PipelinePack
+	spec          *message.MatcherSpecification
+	signer        string
+	inChan        chan *PipelinePack
+	matchSamples  int64
+	matchDuration time.Duration
 }
 
 // Creates and returns a new MatchRunner if possible, or a relevant error if
@@ -215,12 +221,40 @@ func (mr *MatchRunner) Start(matchChan chan *PipelineCapture) {
 			}
 		}()
 
+		var (
+			startTime time.Time
+			random    int = rand.Intn(1000) + 1000000 // don't have everyone sample at the same time
+			// sample every ~1M messages. We always start with a sample so there
+			// will be a ballpark figure immediately. We could use a ticker to
+			// sample at a regular interval but that seems like overkill at this
+			// point.
+			counter  int = random
+			match    bool
+			captures map[string]string
+		)
+
 		for pack := range mr.inChan {
 			if len(mr.signer) != 0 && mr.signer != pack.Signer {
 				pack.Recycle()
 				continue
 			}
-			match, captures := mr.spec.Match(pack.Message)
+			// We may want to keep separate samples for match/nomatch conditions.
+			// In most cases the random sampling will capture the most common
+			// condition which is usesful for the overall system health but not
+			// matcher tuning.  Capturing the duration adds ~40ns
+			if counter == random {
+				mr.matchSamples++
+				startTime = time.Now()
+
+				match, captures = mr.spec.Match(pack.Message)
+
+				mr.matchDuration += time.Since(startTime)
+				counter = 0
+			} else {
+				match, captures = mr.spec.Match(pack.Message)
+				counter++
+			}
+
 			if match {
 				plc := &PipelineCapture{Pack: pack, Captures: captures}
 				matchChan <- plc

--- a/pipeline/sandbox_manager_filter.go
+++ b/pipeline/sandbox_manager_filter.go
@@ -31,9 +31,10 @@ import (
 // dynamically creates, manages, and destroys sandboxed filter scripts as
 // instructed.
 type SandboxManagerFilter struct {
-	maxFilters       int
-	currentFilters   int
-	workingDirectory string
+	maxFilters          int
+	currentFilters      int
+	workingDirectory    string
+	processMessageCount int64
 }
 
 // Config struct for `SandboxManagerFilter`.
@@ -65,6 +66,7 @@ func (this *SandboxManagerFilter) Init(config interface{}) (err error) {
 // Adds running filters count to the report output.
 func (this *SandboxManagerFilter) ReportMsg(msg *message.Message) error {
 	newIntField(msg, "RunningFilters", this.currentFilters)
+	newInt64Field(msg, "ProcessMessageCount", this.processMessageCount)
 	return nil
 }
 
@@ -259,6 +261,7 @@ func (this *SandboxManagerFilter) Run(fr FilterRunner, h PluginHelper) (err erro
 			if !ok {
 				break
 			}
+			this.processMessageCount++
 			action, _ := plc.Pack.Message.GetFieldValue("action")
 			switch action {
 			case "load":


### PR DESCRIPTION
- Issue 200 check the filter, matcher, and router input channel depths.
  If any are at capacity check for a slow matcher or filter and terminate the
  sandbox if necessary.
- Issue 150 Message counts were added to the router and sandbox plugins.
  They can be added to other plugins as desired using a ProcessMessageCount
  field in their ReportMsg function.
- Issue 149 Recording the amount of time each plugin holds onto a message is
  expensive (on my system ~40ns per timer) so instead only sampling is done and
  restricted to the matcher and SandboxFilter where it is required to detect
  problematic code.
