### PR TITLE
statsd gauges should not be additive

### DIFF
--- a/pipeline/statsd_input.go
+++ b/pipeline/statsd_input.go
@@ -226,7 +226,7 @@ func (sm *statMonitor) Monitor(packets <-chan StatPacket, wg *sync.WaitGroup, st
 				sm.timers[s.Bucket] = append(sm.timers[s.Bucket], floatValue)
 			case "g":
 				intValue, _ = strconv.Atoi(s.Value)
-				sm.gauges[s.Bucket] += intValue
+				sm.gauges[s.Bucket] = intValue
 			default:
 				floatValue, _ = strconv.ParseFloat(s.Value, 32)
 				sm.counters[s.Bucket] += int(float32(floatValue) * (1 / s.Sampling))


### PR DESCRIPTION
Gauges are meant to be static snapshots of a value, like "bytes free" for example.

See http://statsd.readthedocs.org/en/v0.5.0/types.html#gauges
