### PR TITLE
Fixes statsd bucket name regex to accept dots

### DIFF
--- a/pipeline/statsd_input.go
+++ b/pipeline/statsd_input.go
@@ -30,7 +30,7 @@ import (
 
 var (
 	sanitizeRegexp = regexp.MustCompile("[^a-zA-Z0-9\\-_\\.:\\|@]")
-	packetRegexp   = regexp.MustCompile("([a-zA-Z0-9_]+):(\\-?[0-9\\.]+)\\|(c|ms|g)(\\|@([0-9\\.]+))?")
+	packetRegexp   = regexp.MustCompile("([a-zA-Z0-9_\\.]+):(\\-?[0-9\\.]+)\\|(c|ms|g)(\\|@([0-9\\.]+))?")
 )
 
 // A Heka Input plugin that handles statsd metric style input and flushes


### PR DESCRIPTION
using dot characters in statsd bucket names helps to organize the data
in tools like graphite. so by sending a bucket named "site.logins" and
another named "site.logouts", in graphite you would have a tree for
"site", that contains "logins" and "logout" nodes.
