### PR TITLE
Issue #241 More accurate sandbox profiling

### DIFF
--- a/cmd/sbmgr/hekad.toml.sbmgr
+++ b/cmd/sbmgr/hekad.toml.sbmgr
@@ -27,7 +27,6 @@ type = "DashboardOutput"
 address = "127.0.0.1:4352"
 ticker_interval = 5
 working_directory = "./dashboard"
-message_matcher = "Type == 'heka.all-report' || Type == 'heka.sandbox-terminated' || Type == 'heka.sandbox-output'"
 
 [TestSandboxManager]
 type = "SandboxManagerFilter"
@@ -57,6 +56,7 @@ preserve_data = true
 memory_limit = 256000
 instruction_limit = 1000
 output_limit = 64000
+profile = true
 
 [SlowMatcher]
 type = "SandboxFilter"

--- a/docs/source/sandbox/filter.rst
+++ b/docs/source/sandbox/filter.rst
@@ -21,6 +21,7 @@ SandboxFilter Settings
  - memory_limit (uint): The number of bytes the sandbox is allowed to consume before being terminated (max 8MiB).
  - instruction_limit (uint): The number of instructions the sandbox is allowed the execute during the process_message/timer_event functions before being terminated (max 1M).
  - output_limit (uint): The number of bytes the sandbox output buffer can hold before before being terminated (max 63KiB).
+ - profile (bool): When true a statistically significant number of ProcessMessage timings are immediately captured before reverting back to the regular sampling interval.  The main purpose is for more accurate sandbox comparison/tuning/optimization.
 
 Example
 
@@ -36,3 +37,4 @@ Example
     memory_limit = 32767
     instruction_limit = 1000
     output_limit = 1024
+    profile = false

--- a/pipeline/dashboard_output.go
+++ b/pipeline/dashboard_output.go
@@ -39,6 +39,8 @@ type DashboardOutputConfig struct {
 	WorkingDirectory string `toml:"working_directory"`
 	// Default interval at which dashboard will update is 5 seconds.
 	TickerInterval uint `toml:"ticker_interval"`
+	// Default message matcher
+	MessageMatcher string
 }
 
 func (self *DashboardOutput) ConfigStruct() interface{} {
@@ -46,6 +48,7 @@ func (self *DashboardOutput) ConfigStruct() interface{} {
 		Address:          ":4352",
 		WorkingDirectory: "./dashboard",
 		TickerInterval:   uint(5),
+		MessageMatcher:   "Type == 'heka.all-report' || Type == 'heka.sandbox-terminated' || Type == 'heka.sandbox-output'",
 	}
 }
 
@@ -464,6 +467,7 @@ func getCbufTemplate() string {
     </script>
 </head>
 <body onload="heka_load_cbuf('%s', load_complete);">
+<a href="heka_report.html">Dashboard</a>
 <p id="title" style="text-align: center">
 </p>
 </body>

--- a/pipeline/report.go
+++ b/pipeline/report.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"github.com/mozilla-services/heka/message"
 	"strings"
+	"sync/atomic"
 )
 
 // Interface for Heka plugins that will provide reporting data. Plugins can
@@ -80,10 +81,11 @@ func PopulateReportMsg(pr PluginRunner, msg *message.Message) (err error) {
 		newIntField(msg, "MatchChanCapacity", cap(fRunner.MatchRunner().inChan), "count")
 		newIntField(msg, "MatchChanLength", len(fRunner.MatchRunner().inChan), "count")
 		var tmp int64 = 0
+		fRunner.MatchRunner().reportLock.Lock()
 		if fRunner.MatchRunner().matchSamples > 0 {
-			tmp = fRunner.MatchRunner().matchDuration.Nanoseconds() /
-				fRunner.MatchRunner().matchSamples
+			tmp = fRunner.MatchRunner().matchDuration / fRunner.MatchRunner().matchSamples
 		}
+		fRunner.MatchRunner().reportLock.Unlock()
 		newInt64Field(msg, "MatchAvgDuration", tmp, "ns")
 	} else if dRunner, ok := pr.(DecoderRunner); ok {
 		newIntField(msg, "InChanCapacity", cap(dRunner.InChan()), "count")
@@ -123,7 +125,7 @@ func (pc *PipelineConfig) reports(reportChan chan *PipelinePack) {
 	msg = pack.Message
 	newIntField(msg, "InChanCapacity", cap(pc.router.InChan()), "count")
 	newIntField(msg, "InChanLength", len(pc.router.InChan()), "count")
-	newInt64Field(msg, "ProcessMessageCount", pc.router.processMessageCount, "count")
+	newInt64Field(msg, "ProcessMessageCount", atomic.LoadInt64(&pc.router.processMessageCount), "count")
 	msg.SetType("heka.router-report")
 	setNameField(msg, "Router")
 	reportChan <- pack

--- a/sandbox/sandbox.go
+++ b/sandbox/sandbox.go
@@ -60,4 +60,5 @@ type SandboxConfig struct {
 	MemoryLimit      uint   `toml:"memory_limit"`
 	InstructionLimit uint   `toml:"instruction_limit"`
 	OutputLimit      uint   `toml:"output_limit"`
+	Profile          bool
 }


### PR DESCRIPTION
- Add a sandbox profile configuration option to gather a larger set of
  ProccessMessage timings
- Add mutexes around the duration calculations since the numerator/denominator
  could be updated during the calculation.
- Change the durations to int64 since it requires less conversions in the code
- update the sandbox configuration docs
- add the default MessageMatcher for the DashboardOutput
