### PR TITLE
Issue #215 Show Input plugins on the dashboard

### DIFF
--- a/pipeline/dashboard_output.go
+++ b/pipeline/dashboard_output.go
@@ -326,47 +326,34 @@ func getReportHtml() string {
 <body class="yui3-skin-sam" style="font-size:.8em">
     <div id="report"></div>
 <script>
-YUI().use("datatable-base", "datasource", "datasource-jsonschema", "datatable-datasource", "datatable-sort", function (Y) {
+YUI().use("datatable-base", "datasource", "datasource-jsonschema", "datatable-datasource", "datatable-sort", "datatype", function (Y) {
 var dataSource = new Y.DataSource.IO({source:"heka_report.json"});
 dataSource.plug({fn: Y.Plugin.DataSourceJSONSchema, cfg: {
         schema: {
             resultListLocator: 'reports',
             resultFields: [
                 'Plugin',
-                {key:'InChanCapacity',locator:'InChanCapacity.value'},
-                {key:'InChanLength',locator:'InChanLength.value'},
-                {key:'MatchChanCapacity',locator:'MatchChanCapacity.value'},
-                {key:'MatchChanLength',locator:'MatchChanLength.value'},
-                {key:'MatchAvgDuration',locator:'MatchAvgDuration.value'},
-                {key:'ProcessMessageCount',locator:'ProcessMessageCount.value'},
-                {key:'InjectMessageCount',locator:'InjectMessageCount.value'},
-                {key:'Memory',locator:'Memory.value'},
-                {key:'MaxMemory',locator:'MaxMemory.value'},
-                {key:'MaxInstructions',locator:'MaxInstructions.value'},
-                {key:'MaxOutput',locator:'MaxOutput.value'},
-                {key:'ProcessMessageAvgDuration',locator:'ProcessMessageAvgDuration.value'},
-                {key:'TimerEventAvgDuration',locator:'TimerEventAvgDuration.value'}
+                {key:'InChanCapacity',locator:'InChanCapacity.value',parser:'number'},
+                {key:'InChanLength',locator:'InChanLength.value',parser:'number'},
+                {key:'MatchChanCapacity',locator:'MatchChanCapacity.value',parser:'number'},
+                {key:'MatchChanLength',locator:'MatchChanLength.value',parser:'number'},
+                {key:'MatchAvgDuration',locator:'MatchAvgDuration.value',parser:'number'},
+                {key:'ProcessMessageCount',locator:'ProcessMessageCount.value',parser:'number'},
+                {key:'InjectMessageCount',locator:'InjectMessageCount.value',parser:'number'}
             ]
         }}
     });
 
 var table = new Y.DataTable({
-    columns: [{key: 'Plugin', sortable:true, formatter: '<a href="{value}.html">{value}</a>', allowHTML: true},
+    columns: [{key: 'Plugin', sortable:true, formatter: '<a href="/{value}.html">{value}</a>', allowHTML: false},
               {key: 'InChanCapacity', sortable:true},
               {key: 'InChanLength', sortable:true},
               {key: 'MatchChanCapacity', sortable:true},
               {key: 'MatchChanLength', sortable:true},
               {key: 'MatchAvgDuration', sortable:true, label: 'MatchAvgDuration (ns)'},
               {key:'ProcessMessageCount', sortable:true, label: 'ProcessedMsgs'},
-              {key:'InjectMessageCount', sortable:true, label: 'InjectedMsgs'},
-              {label: 'Sandbox Metrics', children: [
-                {key:'Memory', sortable:true, label: 'Mem (B)'},
-                {key:'MaxMemory', sortable:true, label: 'MaxMem (B)'},
-                {key:'MaxOutput', sortable:true, label: 'MaxOutput (B)'},
-                {key:'MaxInstructions', sortable:true},
-                {key:'ProcessMessageAvgDuration', sortable:true, label: 'AvgProcess (ns)'},
-                {key:'TimerEventAvgDuration', sortable:true, label: 'AvgOutput (ns)'}
-              ]}],
+              {key:'InjectMessageCount', sortable:true, label: 'InjectedMsgs'}
+              ],
     caption: 'Heka Plugin Report<br/>(cannot find it? see: <a href="heka_sandbox_termination.html">Heka Sandbox Termination Report</a>)'
 });
 table.plug(Y.Plugin.DataTableDataSource, {datasource: dataSource})

--- a/pipeline/report.go
+++ b/pipeline/report.go
@@ -145,12 +145,8 @@ func (pc *PipelineConfig) reports(reportChan chan *PipelinePack) {
 
 	for name, runner := range pc.InputRunners {
 		pack = getReport(runner)
-		if len(pack.Message.Fields) > 0 || pack.Message.GetPayload() != "" {
-			setNameField(pack.Message, name)
-			reportChan <- pack
-		} else {
-			pack.Recycle()
-		}
+		setNameField(pack.Message, name)
+		reportChan <- pack
 	}
 
 	for _, runner := range pc.allDecoders {


### PR DESCRIPTION
- Only the Input plugin names will be displayed since they have no default data
- Dashboard cleanup
  - Add a path to the plugin URL so plugin pages containing a colon can be fetched
  - Fix the sort order on numeric fields
  - Remove the sandbox specific columns since the data is now available on the plugin page
