### PR TITLE
stat_accum_input: rename toml config property name to correct one

### DIFF
--- a/pipeline/stat_accum_input.go
+++ b/pipeline/stat_accum_input.go
@@ -83,7 +83,7 @@ type StatAccumInputConfig struct {
 	CounterPrefix    string `toml:"counter_prefix"`
 	TimerPrefix      string `toml:"timer_prefix"`
 	GaugePrefix      string `toml:"gauge_prefix"`
-	StatsdPrefix     string `toml:"legacy_stats_prefix"`
+	StatsdPrefix     string `toml:"statsd_prefix"`
 }
 
 func (sm *StatAccumInput) ConfigStruct() interface{} {


### PR DESCRIPTION
old name was a remnant of some old idea. In current implementation statsd_prefix fits much better.
