### PR TITLE
added sampling in stats filter

### DIFF
--- a/pipeline/stat_filter.go
+++ b/pipeline/stat_filter.go
@@ -106,6 +106,7 @@ func (s *StatFilter) Run(fr FilterRunner, h PluginHelper) (err error) {
 				stat.Modifier = "g"
 			}
 			stat.Value = InterpolateString(met.Value, values)
+			stat.Sampling = 1.0
 			if !statAccum.DropStat(stat) {
 				fr.LogError(fmt.Errorf("Undelivered stat: %s", stat))
 			}


### PR DESCRIPTION
In the accumulator it divides by sample and it defaults to 0.
This produces unexpected results.
