### PR TITLE
fix memory and socket leak in carbon output

### DIFF
--- a/pipeline/carbon.go
+++ b/pipeline/carbon.go
@@ -49,62 +49,64 @@ func (t *CarbonOutput) Init(config interface{}) (err error) {
 	return
 }
 
-func (t *CarbonOutput) Run(or OutputRunner, h PluginHelper) (err error) {
+func (t *CarbonOutput) ProcessPack(pack *PipelinePack, or OutputRunner) {
 	var e error
 
+	lines := strings.Split(strings.Trim(pack.Message.GetPayload(), " \n"), "\n")
+	pack.Recycle() // Once we've copied the payload we're done w/ the pack.
+
+	clean_statmetrics := make([]string, len(lines))
+	index := 0
+	for _, line := range lines {
+		// `fields` should be "<name> <value> <timestamp>"
+		fields := strings.Fields(line)
+		if len(fields) != 3 || !strings.HasPrefix(fields[0], "stats") {
+			or.LogError(fmt.Errorf("malformed statmetric line: '%s'", line))
+			continue
+		}
+
+		if _, e = strconv.ParseUint(fields[2], 0, 32); e != nil {
+			or.LogError(fmt.Errorf("parsing time: %s", e))
+			continue
+		}
+		if _, e = strconv.ParseFloat(fields[1], 64); e != nil {
+			or.LogError(fmt.Errorf("parsing value '%s': %s", fields[1], e))
+			continue
+		}
+		clean_statmetrics[index] = line
+		index += 1
+	}
+	clean_statmetrics = clean_statmetrics[:index]
+
+	conn, err := net.Dial("tcp", t.address)
+	if err != nil {
+		or.LogError(fmt.Errorf("Dial failed: %s",
+			err.Error()))
+		return
+	}
+	defer conn.Close()
+
+	// Stuff each parseable statmetric into a bytebuffer
+	var buffer bytes.Buffer
+	for i := 0; i < len(clean_statmetrics); i++ {
+		buffer.WriteString(clean_statmetrics[i] + "\n")
+	}
+
+	_, err = conn.Write(buffer.Bytes())
+	if err != nil {
+		or.LogError(fmt.Errorf("Write to server failed: %s",
+			err.Error()))
+	}
+}
+
+func (t *CarbonOutput) Run(or OutputRunner, h PluginHelper) (err error) {
+
 	var (
-		fields []string
-		pack   *PipelinePack
+		pack *PipelinePack
 	)
 
 	for pack = range or.InChan() {
-		lines := strings.Split(strings.Trim(pack.Message.GetPayload(), " \n"), "\n")
-		pack.Recycle() // Once we've copied the payload we're done w/ the pack.
-
-		clean_statmetrics := make([]string, len(lines))
-		index := 0
-		for _, line := range lines {
-			// `fields` should be "<name> <value> <timestamp>"
-			fields = strings.Fields(line)
-			if len(fields) != 3 || !strings.HasPrefix(fields[0], "stats") {
-				or.LogError(fmt.Errorf("malformed statmetric line: '%s'", line))
-				continue
-			}
-
-			if _, e = strconv.ParseUint(fields[2], 0, 32); e != nil {
-				or.LogError(fmt.Errorf("parsing time: %s", e))
-				continue
-			}
-			if _, e = strconv.ParseFloat(fields[1], 64); e != nil {
-				or.LogError(fmt.Errorf("parsing value '%s': %s", fields[1], e))
-				continue
-			}
-			clean_statmetrics[index] = line
-			index += 1
-		}
-		clean_statmetrics = clean_statmetrics[:index]
-
-		conn, err := net.Dial("tcp", t.address)
-		if err != nil {
-			or.LogError(fmt.Errorf("Dial failed: %s",
-				err.Error()))
-			continue
-		}
-		defer conn.Close()
-
-		// Stuff each parseable statmetric into a bytebuffer
-		var buffer bytes.Buffer
-		for i := 0; i < len(clean_statmetrics); i++ {
-			buffer.WriteString(clean_statmetrics[i] + "\n")
-		}
-
-		_, err = conn.Write(buffer.Bytes())
-		if err != nil {
-			or.LogError(fmt.Errorf("Write to server failed: %s",
-				err.Error()))
-			continue
-		}
-
+		t.ProcessPack(pack, or)
 	}
 
 	return


### PR DESCRIPTION
defer functions only run at the end of the function. if you have loop that reads from channel and creates defer in each loop iteration then you will leak memory for every function it saves and the connection won't be closed until the channel is closed which is probably never.

so i just moved the contents of the loop inside of the function. sadly the diff is not very intelligent :( the only thing that i think is different is that the loop no longer updates the err return variable. seeing as the err return variable could be overwritten by a successful iteration of the loop i don't think this is a problem.
