### PR TITLE
Don't restrict the CarbonOutput to only supporting stats w/ the `stats` ...

### DIFF
--- a/pipeline/carbon.go
+++ b/pipeline/carbon.go
@@ -60,7 +60,7 @@ func (t *CarbonOutput) ProcessPack(pack *PipelinePack, or OutputRunner) {
 	for _, line := range lines {
 		// `fields` should be "<name> <value> <timestamp>"
 		fields := strings.Fields(line)
-		if len(fields) != 3 || !strings.HasPrefix(fields[0], "stats") {
+		if len(fields) != 3 {
 			or.LogError(fmt.Errorf("malformed statmetric line: '%s'", line))
 			continue
 		}


### PR DESCRIPTION
...prefix. Resolves #346. 
