### PR TITLE
Issue #263 LogfileInput parsing improvements

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -49,6 +49,10 @@ Bug Handling
 Features
 --------
 
+* Allow LogfileInput to use configurable delimiters including regexp (issue #263)
+  This includes a backwards incompatible change for the journal file, old 
+  journals will not be honored and the new journal will overwrite it.
+
 * Allow add_external_plugin to specify sub-packages (issue #384)
 
 * Added `base_dir` global (i.e. `[hekad]` section) config option to specify a

--- a/cmd/sbmgr/hekad.toml.sbmgr
+++ b/cmd/sbmgr/hekad.toml.sbmgr
@@ -1,5 +1,6 @@
 [hekad]
 maxprocs = 4
+base_dir = "."
 
 [TCP:5565]
 type = "TcpInput"
@@ -123,7 +124,7 @@ instruction_limit = 1000000
 type = "LogfileInput"
 logfile = "./sync-proxy.log"
 decoders = ["SyncProxyDecoder"]
-seekjournal = "./sync-proxy.journal"
+seek_journal_name = "sync-proxy.journal"
 
 [SyncProxyDecoder]
 type = "PayloadRegexDecoder"
@@ -170,7 +171,7 @@ output_limit = 64000
 type = "LogfileInput"
 logfile = "./audit.log"
 decoders = ["AuditLogDecoder"]
-seekjournal = "./audit.journal"
+seek_journal_name = "audit.journal"
 
 [AuditLogDecoder]
 type = "PayloadRegexDecoder"

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -477,7 +477,20 @@ Parameters:
     When heka restarts, if a logfile cannot safely resume reading from
     the last known position, this flag will determine whether hekad
     will force the seek position to be 0 or the end of file. By
-    default, hekad will resume reading from the start of file.
+    default, hekad will resume reading from the start of file.  
+- parser_type (string):
+    - token - splits the log on a byte delimiter (default).
+    - regexp - splits the log on a regexp delimiter.
+- delimiter (string):
+    Character or regexp delimiter used by the parser (default "\\n").  For the 
+    regexp delimiter a single capture group can be specified to preserve the 
+    delimiter (or part of the delimiter). The capture will be added to the start
+    or end of the log line depending on the delimiter_location configuration. 
+    Note: when a start delimiter is used the last line in the file will not be 
+    processed (since the next record defines its end) until the log is rolled.
+- delimiter_location (string): Only used for regexp parsers.
+    - start - the regexp delimiter occurs at the start of a log line.
+    - end - the regexp delimiter occurs at the end of the log line (default).
 
 .. code-block:: ini
 

--- a/pipeline/filemonitor_test.go
+++ b/pipeline/filemonitor_test.go
@@ -100,7 +100,7 @@ func FileMonitorSpec(c gs.Context) {
 			}
 
 			// Expect InputRunner calls to get InChan and inject outgoing msgs
-			ith.MockInputRunner.EXPECT().InChan().Return(ith.PackSupply)
+			ith.MockInputRunner.EXPECT().InChan().Return(ith.PackSupply).Times(numLines)
 			ith.MockInputRunner.EXPECT().Inject(gomock.Any()).Times(numLines)
 			// Expect calls to get decoder and decode each message. Since the
 			// decoding is a no-op, the message payload will be the log file
@@ -133,7 +133,7 @@ func FileMonitorSpec(c gs.Context) {
 		c.Specify("with a previous journal initializes with a seek value", func() {
 			lfInput, lfiConfig := createLogfileInput(journalName)
 
-			journalData := `{"last_hash":"f0b60af7f2cb35c3724151422e2f999af6e21fc0","last_line":"10.1.1.40 plinko-1272.byzantium.mozilla.com user37 [15/Mar/2013:12:20:29 -0700] \"GET /1.1/user37/info/collections HTTP/1.1\" 200 484 \"-\" \"Firefox AndroidSync 1.20.0.1.0 (Firefox)\" \"-\" \"ssl: SSL_RSA_WITH_RC4_128_SHA, version=TLSv1, bits=128\" node_s:0.016658 req_s:0.391589 retries:0 req_b:274 \"c_l:-\"\r\n","seek":28950}`
+			journalData := `{"last_hash":"f0b60af7f2cb35c3724151422e2f999af6e21fc0","last_start":28650,"last_len":300,"seek":28950}`
 
 			journal, journalErr := os.OpenFile(journalPath, os.O_CREATE|os.O_RDWR, 0660)
 			c.Expect(journalErr, gs.Equals, nil)
@@ -154,7 +154,7 @@ func FileMonitorSpec(c gs.Context) {
 			lfInput, lfiConfig := createLogfileInput(journalName)
 			lfiConfig.ResumeFromStart = true
 
-			journalData := `{"last_hash":"xxxxx","last_line":"10.1.1.40 plinko-1272.byzantium.mozilla.com user37 [15/Mar/2013:12:20:29 -0700] \"GET /1.1/user37/info/collections HTTP/1.1\" 200 484 \"-\" \"Firefox AndroidSync 1.20.0.1.0 (Firefox)\" \"-\" \"ssl: SSL_RSA_WITH_RC4_128_SHA, version=TLSv1, bits=128\" node_s:0.016658 req_s:0.391589 retries:0 req_b:274 \"c_l:-\"\r\n","seek":28950}`
+			journalData := `{"last_hash":"xxxxx","last_start":28650,"last_len":300,"seek":28950}`
 
 			journal, journalErr := os.OpenFile(journalPath, os.O_CREATE|os.O_RDWR, 0660)
 			c.Expect(journalErr, gs.Equals, nil)
@@ -173,7 +173,7 @@ func FileMonitorSpec(c gs.Context) {
 			lfInput, lfiConfig := createLogfileInput(journalName)
 			lfiConfig.ResumeFromStart = false
 
-			journalData := `{"last_hash":"xxxxx","last_line":"10.1.1.40 plinko-1272.byzantium.mozilla.com user37 [15/Mar/2013:12:20:29 -0700] \"GET /1.1/user37/info/collections HTTP/1.1\" 200 484 \"-\" \"Firefox AndroidSync 1.20.0.1.0 (Firefox)\" \"-\" \"ssl: SSL_RSA_WITH_RC4_128_SHA, version=TLSv1, bits=128\" node_s:0.016658 req_s:0.391589 retries:0 req_b:274 \"c_l:-\"\r\n","seek":28950}`
+			journalData := `{"last_hash":"xxxxx","last_start":28650,"last_len":300,"seek":28950}`
 
 			journal, journalErr := os.OpenFile(journalPath, os.O_CREATE|os.O_RDWR, 0660)
 			c.Expect(journalErr, gs.Equals, nil)

--- a/pipeline/inputs_test.go
+++ b/pipeline/inputs_test.go
@@ -15,6 +15,7 @@
 package pipeline
 
 import (
+	"bytes"
 	"code.google.com/p/gomock/gomock"
 	"code.google.com/p/goprotobuf/proto"
 	"crypto/hmac"
@@ -28,6 +29,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -409,6 +411,7 @@ func InputsSpec(c gs.Context) {
 		c.Expect(err, gs.IsNil)
 		lfiConfig.LogFile = "../testsupport/test-zeus.log"
 		lfiConfig.Logger = "zeus"
+		lfiConfig.UseSeekJournal = true
 
 		lfiConfig.DiscoverInterval = 1
 		lfiConfig.StatInterval = 1
@@ -433,7 +436,7 @@ func InputsSpec(c gs.Context) {
 			// Expect InputRunner calls to get InChan and inject outgoing msgs
 			ith.MockInputRunner.EXPECT().LogError(gomock.Any()).AnyTimes()
 			ith.MockInputRunner.EXPECT().LogMessage(gomock.Any()).AnyTimes()
-			ith.MockInputRunner.EXPECT().InChan().Return(ith.PackSupply)
+			ith.MockInputRunner.EXPECT().InChan().Return(ith.PackSupply).Times(numLines)
 			ith.MockInputRunner.EXPECT().Inject(gomock.Any()).Times(numLines)
 			// Expect calls to get decoder and decode each message. Since the
 			// decoding is a no-op, the message payload will be the log file
@@ -466,6 +469,13 @@ func InputsSpec(c gs.Context) {
 				c.Expect(packs[i].Message.GetLogger(), gs.Equals, "zeus")
 			}
 			close(lfInput.Monitor.stopChan)
+
+			journalData := []byte(`{"last_hash":"f0b60af7f2cb35c3724151422e2f999af6e21fc0","last_len":300,"last_start":28650,"seek":28950}`)
+			journalFile, err := ioutil.ReadFile(filepath.Join(tmpDir, "seekjournals", lfiConfig.SeekJournalName))
+			c.Expect(err, gs.IsNil)
+			if 0 != bytes.Compare(journalData, journalFile) {
+				t.Errorf("The journal data does not match")
+			}
 		})
 
 		c.Specify("uses the filename as the default logger name", func() {
@@ -481,6 +491,180 @@ func InputsSpec(c gs.Context) {
 			c.Expect(lfInput.Monitor.logger_ident,
 				gs.Equals,
 				lfiConfig.LogFile)
+		})
+	})
+
+	c.Specify("A Regex LogFileInput", func() {
+		tmpDir, tmpErr := ioutil.TempDir("", "hekad-tests-")
+		c.Expect(tmpErr, gs.Equals, nil)
+		origBaseDir := Globals().BaseDir
+		Globals().BaseDir = tmpDir
+		defer func() {
+			Globals().BaseDir = origBaseDir
+			tmpErr = os.RemoveAll(tmpDir)
+			c.Expect(tmpErr, gs.Equals, nil)
+		}()
+		var err error
+		lfInput := new(LogfileInput)
+		lfiConfig := lfInput.ConfigStruct().(*LogfileInputConfig)
+		lfiConfig.SeekJournalName = "regex-seekjournal"
+		c.Expect(err, gs.IsNil)
+		lfiConfig.LogFile = "../testsupport/test-zeus.log"
+		lfiConfig.Logger = "zeus"
+		lfiConfig.ParserType = "regexp"
+		lfiConfig.Delimiter = "(\n)"
+		lfiConfig.UseSeekJournal = true
+
+		lfiConfig.DiscoverInterval = 1
+		lfiConfig.StatInterval = 1
+		err = lfInput.Init(lfiConfig)
+		c.Expect(err, gs.IsNil)
+
+		dName := "decoder-name"
+		lfInput.decoderNames = []string{dName}
+		mockDecoderRunner := NewMockDecoderRunner(ctrl)
+		mockDecoder := NewMockDecoder(ctrl)
+
+		// Create pool of packs.
+		numLines := 95 // # of lines in the log file we're parsing.
+		packs := make([]*PipelinePack, numLines)
+		ith.PackSupply = make(chan *PipelinePack, numLines)
+		for i := 0; i < numLines; i++ {
+			packs[i] = NewPipelinePack(ith.PackSupply)
+			ith.PackSupply <- packs[i]
+		}
+
+		c.Specify("reads a log file", func() {
+			// Expect InputRunner calls to get InChan and inject outgoing msgs
+			ith.MockInputRunner.EXPECT().LogError(gomock.Any()).AnyTimes()
+			ith.MockInputRunner.EXPECT().LogMessage(gomock.Any()).AnyTimes()
+			ith.MockInputRunner.EXPECT().InChan().Return(ith.PackSupply).Times(numLines)
+			ith.MockInputRunner.EXPECT().Inject(gomock.Any()).Times(numLines)
+			// Expect calls to get decoder and decode each message. Since the
+			// decoding is a no-op, the message payload will be the log file
+			// line, unchanged.
+			ith.MockHelper.EXPECT().DecoderSet().Return(ith.MockDecoderSet)
+			pbcall := ith.MockDecoderSet.EXPECT().ByName(dName)
+			pbcall.Return(mockDecoderRunner, true)
+			mockDecoderRunner.EXPECT().Decoder().Return(mockDecoder)
+			decodeCall := mockDecoder.EXPECT().Decode(gomock.Any()).Times(numLines)
+			decodeCall.Return(nil)
+			go func() {
+				err = lfInput.Run(ith.MockInputRunner, ith.MockHelper)
+				c.Expect(err, gs.IsNil)
+			}()
+			for len(ith.PackSupply) > 0 {
+				// Free up the scheduler while we wait for the log file lines
+				// to be processed.
+				runtime.Gosched()
+			}
+
+			fileBytes, err := ioutil.ReadFile(lfiConfig.LogFile)
+			c.Expect(err, gs.IsNil)
+			fileStr := string(fileBytes)
+			lines := strings.Split(fileStr, "\n")
+			for i, line := range lines {
+				if line == "" {
+					continue
+				}
+				c.Expect(packs[i].Message.GetPayload(), gs.Equals, line+"\n")
+				c.Expect(packs[i].Message.GetLogger(), gs.Equals, "zeus")
+			}
+			close(lfInput.Monitor.stopChan)
+
+			journalData := []byte(`{"last_hash":"f0b60af7f2cb35c3724151422e2f999af6e21fc0","last_len":300,"last_start":28650,"seek":28950}`)
+			journalFile, err := ioutil.ReadFile(filepath.Join(tmpDir, "seekjournals", lfiConfig.SeekJournalName))
+			c.Expect(err, gs.IsNil)
+			if 0 != bytes.Compare(journalData, journalFile) {
+				t.Errorf("The journal data does not match")
+			}
+		})
+	})
+
+	c.Specify("A Regex Multiline LogFileInput", func() {
+		tmpDir, tmpErr := ioutil.TempDir("", "hekad-tests-")
+		c.Expect(tmpErr, gs.Equals, nil)
+		origBaseDir := Globals().BaseDir
+		Globals().BaseDir = tmpDir
+		defer func() {
+			Globals().BaseDir = origBaseDir
+			tmpErr = os.RemoveAll(tmpDir)
+			c.Expect(tmpErr, gs.Equals, nil)
+		}()
+		var err error
+		lfInput := new(LogfileInput)
+		lfiConfig := lfInput.ConfigStruct().(*LogfileInputConfig)
+		lfiConfig.SeekJournalName = "multiline-seekjournal"
+		c.Expect(err, gs.IsNil)
+		lfiConfig.LogFile = "../testsupport/multiline.log"
+		lfiConfig.Logger = "multiline"
+		lfiConfig.ParserType = "regexp"
+		lfiConfig.Delimiter = "\n(\\d{4}-\\d{2}-\\d{2})"
+		lfiConfig.DelimiterLocation = "start"
+		lfiConfig.UseSeekJournal = true
+
+		lfiConfig.DiscoverInterval = 1
+		lfiConfig.StatInterval = 1
+		err = lfInput.Init(lfiConfig)
+		c.Expect(err, gs.IsNil)
+
+		dName := "decoder-name"
+		lfInput.decoderNames = []string{dName}
+		mockDecoderRunner := NewMockDecoderRunner(ctrl)
+		mockDecoder := NewMockDecoder(ctrl)
+
+		// Create pool of packs.
+		numLines := 4 // # of lines in the log file we're parsing.
+		packs := make([]*PipelinePack, numLines)
+		ith.PackSupply = make(chan *PipelinePack, numLines)
+		for i := 0; i < numLines; i++ {
+			packs[i] = NewPipelinePack(ith.PackSupply)
+			ith.PackSupply <- packs[i]
+		}
+
+		c.Specify("reads a log file", func() {
+			// Expect InputRunner calls to get InChan and inject outgoing msgs
+			ith.MockInputRunner.EXPECT().LogError(gomock.Any()).AnyTimes()
+			ith.MockInputRunner.EXPECT().LogMessage(gomock.Any()).AnyTimes()
+			ith.MockInputRunner.EXPECT().InChan().Return(ith.PackSupply).Times(numLines)
+			ith.MockInputRunner.EXPECT().Inject(gomock.Any()).Times(numLines)
+			// Expect calls to get decoder and decode each message. Since the
+			// decoding is a no-op, the message payload will be the log file
+			// line, unchanged.
+			ith.MockHelper.EXPECT().DecoderSet().Return(ith.MockDecoderSet)
+			pbcall := ith.MockDecoderSet.EXPECT().ByName(dName)
+			pbcall.Return(mockDecoderRunner, true)
+			mockDecoderRunner.EXPECT().Decoder().Return(mockDecoder)
+			decodeCall := mockDecoder.EXPECT().Decode(gomock.Any()).Times(numLines)
+			decodeCall.Return(nil)
+			go func() {
+				err = lfInput.Run(ith.MockInputRunner, ith.MockHelper)
+				c.Expect(err, gs.IsNil)
+			}()
+			for len(ith.PackSupply) > 0 {
+				// Free up the scheduler while we wait for the log file lines
+				// to be processed.
+				runtime.Gosched()
+			}
+
+			lines := []string{
+				"2012-07-13 18:48:01 debug    readSocket()",
+				"2012-07-13 18:48:21 info     Processing queue id 3496 -> subm id 2817 from site ms",
+				"2012-07-13 18:48:25 debug    line0\nline1\nline2",
+				"2012-07-13 18:48:26 debug    readSocket()",
+			}
+			for i, line := range lines {
+				c.Expect(packs[i].Message.GetPayload(), gs.Equals, line)
+				c.Expect(packs[i].Message.GetLogger(), gs.Equals, "multiline")
+			}
+			close(lfInput.Monitor.stopChan)
+
+			journalData := []byte(`{"last_hash":"39e4c3e6e9c88a794b3e7c91c155682c34cf1a4a","last_len":41,"last_start":172,"seek":214}`)
+			journalFile, err := ioutil.ReadFile(filepath.Join(tmpDir, "seekjournals", lfiConfig.SeekJournalName))
+			c.Expect(err, gs.IsNil)
+			if 0 != bytes.Compare(journalData, journalFile) {
+				t.Errorf("The journal data does not match")
+			}
 		})
 	})
 }

--- a/pipeline/logfile_input_test.go
+++ b/pipeline/logfile_input_test.go
@@ -99,7 +99,7 @@ func LogfileInputSpec(c gs.Context) {
 			}
 
 			// Expect InputRunner calls to get InChan and inject outgoing msgs
-			ith.MockInputRunner.EXPECT().InChan().Return(ith.PackSupply)
+			ith.MockInputRunner.EXPECT().InChan().Return(ith.PackSupply).Times(numLines)
 			ith.MockInputRunner.EXPECT().Inject(gomock.Any()).Times(numLines)
 			// Expect calls to get decoder and decode each message. Since the
 			// decoding is a no-op, the message payload will be the log file

--- a/testsupport/multiline.log
+++ b/testsupport/multiline.log
@@ -1,0 +1,7 @@
+2012-07-13 18:48:01 debug    readSocket()
+2012-07-13 18:48:21 info     Processing queue id 3496 -> subm id 2817 from site ms
+2012-07-13 18:48:25 debug    line0
+line1
+line2
+2012-07-13 18:48:26 debug    readSocket()
+2012-07-13 18:48:26 debug    Checking Queue...


### PR DESCRIPTION
- Fix the file handle leak in file discovery
- Update the journal to store the location and length of the last record
  (not backwards compatible, existing journal files will fail to load and a new one created)
- Add the regexp parser
- Keep the token parser since there are some performance benefits (10-15%)
  over the regexp parser (mainly do to the final conversion from byte array to string)
- Remove the Logline struct and use a pipeline pack instead. This is cleanup and
  preparation for the protobuf parser which needs access to the pack and message)
