### PR TITLE
Issue #402 Increase the amount of time a sandbox can use before being te...

### DIFF
--- a/pipeline/router.go
+++ b/pipeline/router.go
@@ -229,8 +229,9 @@ func (mr *MatchRunner) Start(matchChan chan *PipelinePack) {
 			// a sample so there will be a ballpark figure immediately. We could
 			// use a ticker to sample at a regular interval but that seems like
 			// overkill at this  point.
-			counter int = random
-			match   bool
+			counter  int = random
+			match    bool
+			duration int64
 		)
 
 		var capacity int64 = int64(cap(mr.inChan))
@@ -248,8 +249,9 @@ func (mr *MatchRunner) Start(matchChan chan *PipelinePack) {
 
 				match = mr.spec.Match(pack.Message)
 
+				duration = time.Since(startTime).Nanoseconds()
 				mr.reportLock.Lock()
-				mr.matchDuration += time.Since(startTime).Nanoseconds()
+				mr.matchDuration += duration
 				mr.matchSamples++
 				mr.reportLock.Unlock()
 				if mr.matchSamples > capacity {

--- a/pipeline/sandbox_decoder.go
+++ b/pipeline/sandbox_decoder.go
@@ -119,8 +119,9 @@ func (s *SandboxDecoder) Decode(pack *PipelinePack) error {
 	}
 	retval := s.sb.ProcessMessage(s.pack.Message)
 	if s.sample {
+		duration := time.Since(startTime).Nanoseconds()
 		s.reportLock.Lock()
-		s.processMessageDuration += time.Since(startTime).Nanoseconds()
+		s.processMessageDuration += duration
 		s.processMessageSamples++
 		s.reportLock.Unlock()
 	}

--- a/pipeline/sandbox_filter.go
+++ b/pipeline/sandbox_filter.go
@@ -149,8 +149,9 @@ func (this *SandboxFilter) Run(fr FilterRunner, h PluginHelper) (err error) {
 		msgLoopCount   uint
 		injectionCount uint
 		startTime      time.Time
-		slowDuration   int64 = 50000 // duration in nanoseconds (20K msg/sec)
-		capacity             = cap(inChan) - 1
+		slowDuration   int64 = 100000 // duration in nanoseconds
+		duration       int64
+		capacity       = cap(inChan) - 1
 	)
 
 	this.sb.InjectMessage(func(payload, payload_type, payload_name string) int {
@@ -219,8 +220,9 @@ func (this *SandboxFilter) Run(fr FilterRunner, h PluginHelper) (err error) {
 			}
 			retval = this.sb.ProcessMessage(pack.Message)
 			if sample {
+				duration = time.Since(startTime).Nanoseconds()
 				this.reportLock.Lock()
-				this.processMessageDuration += time.Since(startTime).Nanoseconds()
+				this.processMessageDuration += duration
 				this.processMessageSamples++
 				if this.sbc.Profile {
 					this.profileMessageDuration = this.processMessageDuration
@@ -260,8 +262,9 @@ func (this *SandboxFilter) Run(fr FilterRunner, h PluginHelper) (err error) {
 			if retval = this.sb.TimerEvent(t.UnixNano()); retval != 0 {
 				terminated = true
 			}
+			duration = time.Since(startTime).Nanoseconds()
 			this.reportLock.Lock()
-			this.timerEventDuration += time.Since(startTime).Nanoseconds()
+			this.timerEventDuration += duration
 			this.timerEventSamples++
 			this.reportLock.Unlock()
 		}


### PR DESCRIPTION
...rminated
- Capture the duration before the report lock so it is not included
  in the sample.
