### PR TITLE
Keep json numbers as strings in PayloadJsonDecoder

### DIFF
--- a/pipeline/decoders_test.go
+++ b/pipeline/decoders_test.go
@@ -197,7 +197,7 @@ func DecodersSpec(c gospec.Context) {
 			var name, count interface{}
 			count, ok = pack.Message.GetFieldValue("StatCount")
 			c.Expect(ok, gs.Equals, true)
-			c.Expect(count, gs.Equals, "1.000000000")
+			c.Expect(count, gs.Equals, "1")
 
 			name, ok = pack.Message.GetFieldValue("StatName")
 			c.Expect(ok, gs.Equals, true)

--- a/pipeline/jsonpath.go
+++ b/pipeline/jsonpath.go
@@ -33,7 +33,9 @@ var json_re = regexp.MustCompile(`^([^0-9\s\[][^\s\[]*)?(\[[0-9]+\])?$`)
 
 func (j *JsonPath) SetJsonText(json_text string) (err error) {
 	j.json_text = json_text
-	err = json.Unmarshal([]byte(json_text), &j.json_data)
+	dec := json.NewDecoder(strings.NewReader(json_text))
+	dec.UseNumber()
+	err = dec.Decode(&j.json_data)
 	return
 }
 
@@ -78,10 +80,6 @@ func (j *JsonPath) Find(jp string) (result string, err error) {
 	r_kind := reflect.ValueOf(v).Kind()
 	if r_kind == reflect.Bool {
 		result = fmt.Sprintf("%t", v)
-	} else if r_kind == reflect.Float64 {
-		result = fmt.Sprintf("%0.9f", v)
-	} else if r_kind == reflect.Int64 {
-		result = fmt.Sprintf("%d", v)
 	} else if r_kind == reflect.Map || r_kind == reflect.Slice {
 		json_str, _ := json.Marshal(v)
 		result = fmt.Sprintf("%s", json_str)

--- a/pipeline/jsonpath_test.go
+++ b/pipeline/jsonpath_test.go
@@ -30,7 +30,8 @@ func JsonPathSpec(c gs.Context) {
 			},
 			{
 				"maz": "123",
-				"moo": 256
+				"moo": 256,
+				"muux": 2.10
 			}
 		],
 		"boo": {
@@ -65,7 +66,11 @@ func JsonPathSpec(c gs.Context) {
 
 		result, err = json_path.Find("$.foo.bar[1].moo")
 		c.Expect(err, gs.IsNil)
-		c.Expect(result, gs.Equals, "256.000000000")
+		c.Expect(result, gs.Equals, "256")
+
+		result, err = json_path.Find("$.foo.bar[1].muux")
+		c.Expect(err, gs.IsNil)
+		c.Expect(result, gs.Equals, "2.10")
 
 		result, err = json_path.Find("$.foo.boo.bag")
 		c.Expect(err, gs.IsNil)
@@ -87,7 +92,7 @@ func JsonPathSpec(c gs.Context) {
 		result, err = json_path.Find("$.foo.bar.3428")
 		c.Expect(err, gs.Not(gs.IsNil))
 
-		expected_data := `[{"baz":"こんにちわ世界","noo":"aaa"},{"maz":"123","moo":256}]`
+		expected_data := `[{"baz":"こんにちわ世界","noo":"aaa"},{"maz":"123","moo":256,"muux":2.10}]`
 		result_data, err := json_path.Find("$.foo.bar")
 		c.Expect(err, gs.IsNil)
 		c.Expect(result_data, gs.Equals, expected_data)


### PR DESCRIPTION
When a json number gets unmarshaled into an interface{}, it's interpreted
as a float64. When this gets converted back to a string (a few lines later),
it's forced to the format "%0.9f", which adds nine zeros after integer
values. Package encoding/json allows us to skip the two conversion steps,
which allows integers to remain integers.
