### PR TITLE
Fix libc6 dependency in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ elseif(UNIX)
     find_program(DPKG_EXECUTABLE dpkg PATH_SUFFIXES bin)
     if (DPKG_EXECUTABLE)
         set(CPACK_GENERATOR ${CPACK_GENERATOR} "DEB")
-        set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.14")
+        set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.14)")
     endif()
 
     find_program(RPMBUILD_EXECUTABLE rpmbuild PATH_SUFFIXES bin)


### PR DESCRIPTION
After running `source build.sh` and then `cpack` in the `build/` directory, the resulting .deb could not be installed.

The full output is:

```
$ sudo dpkg -i heka-0_4_0-linux-amd64.deb 
dpkg: error processing heka-0_4_0-linux-amd64.deb (--install):
 parsing file '/var/lib/dpkg/tmp.ci/control' near line 6 package 'heka-0_4_0-linux-amd64':
 `Depends' field, syntax error after reference to package `libc6'
Errors were encountered while processing:
 heka-0_4_0-linux-amd64.deb

```

Running `dpkg --info heka-0_4_0-linux-amd64.deb` showed missing brackets around `libc6 >= 2.14`.

This is fixed by adding a closing bracket in the dependency declaration.
