### PR TITLE
Specifying an ajax data type to prevent issues with mime type detection.

### DIFF
--- a/dasher/javascript/adapters/base_adapter.js
+++ b/dasher/javascript/adapters/base_adapter.js
@@ -56,7 +56,7 @@ define(
       * @param {jqXHR} callback.jqXHR jQuery XHR object representing the request
       */
       fetch: function(url, callback) {
-        $.ajax(url, { cache: false }).then(function(data, textStatus, jqXHR) {
+        $.ajax(url, { dataType: this.getDataType(url), cache: false }).then(function(data, textStatus, jqXHR) {
           var responseTextCode = crc32(jqXHR.responseText);
 
           if (this.lastFetchResponseCode !== responseTextCode) {
@@ -65,6 +65,28 @@ define(
             callback(data, textStatus, jqXHR);
           }
         }.bind(this));
+      },
+
+      /**
+      * Determines the jQuery ajax data type based the extension in a URL.
+      *
+      * This makes the dashboard more resilient to incorrect mime types returned from the server.
+      *
+      * @method getDataType
+      * @param {String} url URL used to determine the data type
+      */
+      getDataType: function(url) {
+        var dataType;
+
+        if (url.match(/\.json$/)) {
+          dataType = "json";
+        } else if (url.match(/\.xml$/)) {
+          dataType = "xml";
+        } else {
+          dataType = "text";
+        }
+
+        return dataType;
       },
 
       /**


### PR DESCRIPTION
In certain circumstances the hekad web server was returning the wrong mime type for json files and breaking decoding. The data type is now being specified based on the URL to prevent this from happening in the future.
