### PR TITLE
CommandChain and ManagedCmd fixes to prevent goroutine leakage

### DIFF
--- a/pipeline/inputs_test.go
+++ b/pipeline/inputs_test.go
@@ -206,7 +206,7 @@ func InputsSpec(c gs.Context) {
 			err := pInput.Init(config)
 			c.Assume(err, gs.IsNil)
 
-			expected_err := fmt.Errorf("BadArgs CommandChain::Wait() error: [exit status 1]")
+			expected_err := fmt.Errorf("BadArgs CommandChain::Wait() error: [Subcommand returned an error: [exit status 1]]")
 			ith.MockInputRunner.EXPECT().LogError(expected_err)
 
 			go func() {

--- a/pipeline/process_chain_test.go
+++ b/pipeline/process_chain_test.go
@@ -190,9 +190,8 @@ func ProcessChainSpec(c gs.Context) {
 			end := time.Now()
 			actual_duration := end.Sub(start)
 			c.Expect(err, gs.Not(gs.IsNil))
-
+			c.Expect(strings.Contains(err.Error(), "was killed"), gs.Equals, true)
 			c.Expect(actual_duration < time.Second*10, gs.Equals, true)
-			c.Expect(strings.Contains(err.Error(), "timedout"), gs.Equals, true)
 		})
 
 		c.Specify("will stop chains before timeout has completed", func() {


### PR DESCRIPTION
This is part of #505 and should prevent any goroutines from leaking in the ProcessInput code.
- invoke drainChannels prior to exiting from ManagedCmd::Wait()
- ManagedCmd timeout is just a special case of Stopping now to prevent goroutine leaks
- CommandChain was leaking goroutines on subcommand error. Chains now
  report a single aggregate error to prevent goroutine leaks.
