### PR TITLE
Explicitly log fatal SandboxDecoder errors so they actually show up in

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -30,6 +30,9 @@ Backwards Incompatibilities
 Bug Handling
 ------------
 
+* SandboxDecoder now explicitly logs a fatal error before triggering shutdown
+  to ensure error message is actually emitted.
+
 * Message severity now defaults to the highest RFC 5424 value (i.e. 7) implies
   low severity, rather than zero, which implies `emergency`, (issue #518).
 

--- a/sandbox/plugins/sandbox_decoder.go
+++ b/sandbox/plugins/sandbox_decoder.go
@@ -41,6 +41,7 @@ type SandboxDecoder struct {
 	err                    error
 	pack                   *pipeline.PipelinePack
 	packs                  []*pipeline.PipelinePack
+	dRunner                pipeline.DecoderRunner
 }
 
 func (pd *SandboxDecoder) ConfigStruct() interface{} {
@@ -116,6 +117,7 @@ func copyMessageHeaders(dst *message.Message, src *message.Message) {
 }
 
 func (s *SandboxDecoder) SetDecoderRunner(dr pipeline.DecoderRunner) {
+	s.dRunner = dr
 	var original *message.Message
 
 	s.sb.InjectMessage(func(payload, payload_type, payload_name string) int {
@@ -202,7 +204,8 @@ func (s *SandboxDecoder) Decode(pack *pipeline.PipelinePack) (packs []*pipeline.
 	}
 	s.sample = 0 == rand.Intn(pipeline.DURATION_SAMPLE_DENOMINATOR)
 	if retval > 0 {
-		s.err = errors.New("fatal: " + s.sb.LastError())
+		s.err = errors.New("FATAL: " + s.sb.LastError())
+		s.dRunner.LogError(s.err)
 		pipeline.Globals().ShutDown()
 	}
 	if retval < 0 {


### PR DESCRIPTION
the output before Heka is shut down.
