### PR TITLE
Fix StatFilter Parameter to Match Documentation

### DIFF
--- a/plugins/statsd/stat_filter.go
+++ b/plugins/statsd/stat_filter.go
@@ -46,7 +46,7 @@ type StatFilterConfig struct {
 	Metric map[string]metric
 	// Configured name of StatAccumInput plugin to which this filter should be
 	// delivering its stats. Defaults to "StatsAccumInput".
-	StatAccumName string `toml:"stat_accum_input"`
+	StatAccumName string `toml:"stat_accum_name"`
 }
 
 func (s *StatFilter) ConfigStruct() interface{} {


### PR DESCRIPTION
Docs suggest (and give example) that this parameter should be stat_accum_name, not stat_accum_input.
