### PR TITLE
simple,configurable check to exit on failed tcp writes

### DIFF
--- a/plugins/tcp/tcp_output.go
+++ b/plugins/tcp/tcp_output.go
@@ -23,24 +23,27 @@ import (
 
 // Output plugin that sends messages via TCP using the Heka protocol.
 type TcpOutput struct {
-	address    string
-	connection net.Conn
+	address       string
+	connection    net.Conn
+	exitonfailure bool
 }
 
 // ConfigStruct for TcpOutput plugin.
 type TcpOutputConfig struct {
 	// String representation of the TCP address to which this output should be
 	// sending data.
-	Address string
+	Address       string
+	ExitOnFailure bool
 }
 
 func (t *TcpOutput) ConfigStruct() interface{} {
-	return &TcpOutputConfig{Address: "localhost:9125"}
+	return &TcpOutputConfig{Address: "localhost:9125", ExitOnFailure: false}
 }
 
 func (t *TcpOutput) Init(config interface{}) (err error) {
 	conf := config.(*TcpOutputConfig)
 	t.address = conf.Address
+	t.exitonfailure = conf.ExitOnFailure
 	t.connection, err = net.Dial("tcp", t.address)
 	return
 }
@@ -61,6 +64,9 @@ func (t *TcpOutput) Run(or OutputRunner, h PluginHelper) (err error) {
 
 		if n, e = t.connection.Write(outBytes); e != nil {
 			or.LogError(fmt.Errorf("writing to %s: %s", t.address, e))
+			if t.exitonfailure {
+				return
+			}
 		} else if n != len(outBytes) {
 			or.LogError(fmt.Errorf("truncated output to: %s", t.address))
 		}


### PR DESCRIPTION
Currently, hekad configured to write to a remote TCP socket will not recover from that remote TCP socket changing state ie. going through a restart or simply closing down.

I propose the option to configure hekad exit on failed writes to that remote socket.

I spent a few hours dreaming up re-connects, but was never satisfied with any solution when really I desire that any local plugins or downstream agents be made aware of a failed write (in my case a logfile reader which can benefit from not advancing the index thereby utilizing a disk buffer of sorts.)

This solution implies moving any desired restart behavior into a process manager like circus, upstart, etc.. It's easy to comprehend and configure and should be backwards compatible with existing config files.
