### PR TITLE
NagiosOutput improvements: send_nsca support, explicit host/service, skip certificate verification

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -65,6 +65,10 @@ Bug Handling
 Features
 --------
 
+* Added support for send_nsca to NagiosOutput as an alternative to direct http
+  submission; also a way to explicitely specify service_description and host to
+  match Nagios config
+
 * TcpOutput has been redesigned to handle unavailable endpoints and dropped 
   connections without data loss (issue #355)
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1949,6 +1949,22 @@ Parameters:
 - responseheadertimeout (uint, optional):
     Specifies the amount of time, in seconds, to wait for a server's response
     headers after fully writing the request. Defaults to 2.
+- nagios_service_description (string, optional)
+	Must match Nagios service's service_description attribute.
+	(default: the name of the output)
+- nagios_host (string, optional)
+	Must match the hostname of the server in nagios.
+	(default: the Hostname attribute of the message)
+- send_nsca_bin (string, optional)
+    Use send_nsca program, as provided, rather than sending direct http requests
+    (default: "", use http)
+- send_nsca_args ([]string, optional)
+    Arguments to use with send_nsca, usually at least the nagios hostname, e.g. ["-H", "nagios.somehost.com"]
+    (default: "")
+- send_nsca_timeout (int, optional)
+    Timeout for the send_nsca command, in seconds
+    (default: 5)
+
 
 Example configuration to output alerts from SandboxFilter plugins:
 

--- a/plugins/nagios/nagios_output.go
+++ b/plugins/nagios/nagios_output.go
@@ -15,15 +15,38 @@
 package nagios
 
 import (
+	"github.com/mozilla-services/heka/plugins/process"
 	"github.com/mozilla-services/heka/message"
 	. "github.com/mozilla-services/heka/pipeline"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+	"crypto/tls"
+	"fmt"
 )
 
+// NagiosOutput can be configured to use the http client to submit the passive
+// checks directly to the nagios cgi, or pipe them to the send_nsca program.
+//   -	To use send_nsca, one needs to provide the send_nsca_bin, and optionally
+//	send_nsca_args config entries.
+//   -	To use http, one needs to provide Url, and optionally username, password,
+//	and responseheadertimeout
 type NagiosOutputConfig struct {
+	// Must match Nagios service's service_description attribute; if not
+	// specified in the config explicitly, the name of the output is used.
+	NagiosServiceDescription string `toml:"nagios_service_description"`
+
+	// Must match the hostname of the server in nagios. If not specified in
+	// the config explicitly, use the Hostname attribute of the message
+	NagiosHost string `toml:"nagios_host"`
+
+	// SendNSCA tells the plugin to pipe the commands into a send_nsca program rather than
+	// submitting each command using the go http client. The timeout is in seconds.
+	SendNscaBin string `toml:"send_nsca_bin"`
+	SendNscaArgs []string `toml:"send_nsca_args"`
+	SendNscaTimeoutSeconds uint `toml:"send_nsca_timeout"`
+
 	// URL to the Nagios cmd.cgi
 	Url string
 	// Nagios username
@@ -32,27 +55,44 @@ type NagiosOutputConfig struct {
 	Password string
 	// Http ResponseHeaderTimeout in seconds
 	ResponseHeaderTimeout uint
+	// when set, insecure_tls_skip_verify bypasses the server SSL certificate validation (NOT SECURE!!!)
+	SkipVerify bool `toml: "insecure_tls_skip_verify"`
 }
 
 func (n *NagiosOutput) ConfigStruct() interface{} {
 	return &NagiosOutputConfig{
 		Url: "http://localhost/cgi-bin/cmd.cgi",
 		ResponseHeaderTimeout: 2,
+		SendNscaTimeoutSeconds: 5,
 	}
 }
 
 type NagiosOutput struct {
 	conf      *NagiosOutputConfig
 	client    *http.Client
-	transport *http.Transport
+	submitter func (or OutputRunner, h PluginHelper, host, service_description, state, output string) (err error)
 }
 
 func (n *NagiosOutput) Init(config interface{}) (err error) {
 	n.conf = config.(*NagiosOutputConfig)
-	n.transport = &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		ResponseHeaderTimeout: time.Duration(n.conf.ResponseHeaderTimeout) * time.Second}
-	n.client = &http.Client{Transport: n.transport}
+
+	n.submitter = n.submitSendNsca
+	if n.conf.SendNscaBin == "" {
+		// use http
+		n.submitter = n.submitHttp
+		var tlsconf *tls.Config
+		if n.conf.SkipVerify {
+			tlsconf = &tls.Config {InsecureSkipVerify: true}
+		}
+
+		n.client = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: tlsconf,
+				Proxy: http.ProxyFromEnvironment,
+				ResponseHeaderTimeout: time.Duration(n.conf.ResponseHeaderTimeout) * time.Second,
+			},
+		}
+	}
 	return
 }
 
@@ -81,27 +121,73 @@ func (n *NagiosOutput) Run(or OutputRunner, h PluginHelper) (err error) {
 			}
 		}
 
-		data := url.Values{
-			"cmd_typ":          {"30"}, // PROCESS_SERVICE_CHECK_RESULT
-			"cmd_mod":          {"2"},  // CMDMODE_COMMIT
-			"host":             {msg.GetHostname()},
-			"service":          {msg.GetLogger()},
-			"plugin_state":     {state},
-			"plugin_output":    {payload[pos+1:]},
-			"performance_data": {""}}
-		req, err := http.NewRequest("POST", n.conf.Url,
-			strings.NewReader(data.Encode()))
-		if err == nil {
-			req.SetBasicAuth(n.conf.Username, n.conf.Password)
-			if resp, err := n.client.Do(req); err == nil {
-				resp.Body.Close()
-			} else {
-				or.LogError(err)
-			}
-		} else {
-			or.LogError(err)
+		host := n.conf.NagiosHost
+		if host == "" {
+			host = msg.GetHostname()
 		}
+		service_description := n.conf.NagiosServiceDescription
+		if service_description == "" {
+			service_description = msg.GetLogger()
+		}
+		payload = payload [pos+1:]
+
+		err = n.submitter (or, h, host, service_description, state, payload)
+		if err != nil {
+			or.LogError (err)
+		}
+
 		pack.Recycle()
+	}
+	return
+}
+
+func (n *NagiosOutput) submitSendNsca(or OutputRunner, h PluginHelper, host, service_description, state, output string) (err error) {
+	c := process.NewManagedCmd (n.conf.SendNscaBin, n.conf.SendNscaArgs, time.Duration(n.conf.SendNscaTimeoutSeconds) * time.Second)
+	cmdin, err := c.StdinPipe()
+	if err != nil {
+		return
+	}
+	defer cmdin.Close()
+	err = c.Start(false)
+	if err != nil {
+		return
+	}
+
+	_, err = fmt.Fprintf (cmdin, "%s\t%s\t%v\t%s\n", host, service_description, state, output)
+	if err != nil {
+		return
+	}
+
+	// close the input pipe to terminate send_nsca
+	cmdin.Close()
+
+	err = c.Wait()
+	return
+}
+
+func (n *NagiosOutput) submitHttp(or OutputRunner, h PluginHelper, host, service_description, state, output string) (err error) {
+	data := url.Values{
+		"cmd_typ":          {"30"}, // PROCESS_SERVICE_CHECK_RESULT
+		"cmd_mod":          {"2"},  // CMDMODE_COMMIT
+		"host":             {host},
+		"service":          {service_description},
+		"plugin_state":     {state},
+		"plugin_output":    { output },
+		"performance_data": {""},
+	}
+
+	req, err := http.NewRequest("POST", n.conf.Url, strings.NewReader(data.Encode()))
+	if err != nil {
+		return
+	}
+	req.SetBasicAuth(n.conf.Username, n.conf.Password)
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return
+	}
+	err = resp.Body.Close()
+	if err != nil {
+		return
 	}
 	return
 }


### PR DESCRIPTION
- Added support for sending nagios passive checks using send_nsca; config options: send_nsca_bin, send_nsca_args, send_nsca_timeout
- Added configuration parameters to Nagios output for finer control of the nagios data: nagios_host, nagios_service_description
- Added a configuration parmeter to skip certificate checks when using https: insecure_tls_skip_verify
