### PR TITLE
Syntax error in: Parsing Apache Combined Log Format

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -969,7 +969,7 @@ Example (Parsing Apache Combined Log Format):
     [apache_transform_decoder]
     type = "PayloadRegexDecoder"
     match_regex = '/^(?P<RemoteIP>\S+) \S+ \S+ \[(?P<Timestamp>[^\]]+)\] "(?P<Method>[A-Z]+) (?P<Url>[^\s]+)[^"]*" (?P<StatusCode>\d+) (?P<RequestSize>\d+) "(?P<Referer>[^"]*)" "(?P<Browser>[^"]*)"/'
-    timestamplayout = "02/Jan/2006:15:04:05 -0700"
+    timestamp_layout = "02/Jan/2006:15:04:05 -0700"
 
     # severities in this case would work only if a (?P<Severity>...) matching
     # group was present in the regex, and the log file contained this information.


### PR DESCRIPTION
This commit corrects the configuration example.

The example was ommiting the _ char

```
modified:   docs/source/configuration.rst
```
