### PR TITLE
Set the 'Hostname' against the correct variable.

### DIFF
--- a/plugins/logstreamer/logstreamer_input.go
+++ b/plugins/logstreamer/logstreamer_input.go
@@ -147,7 +147,7 @@ func (li *LogstreamerInput) Init(config interface{}) (err error) {
 
 	// Declare our hostname
 	if conf.Hostname == "" {
-		li.hostName, err = os.Hostname()
+		conf.Hostname, err = os.Hostname()
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
This correctly sets the Hostname value, otherwise it's an empty string.

I couldn't work out where to hook in tests for this as it wasn't clear how the logstreamer plugin uses `Message` structs. However, this method is used in 3 other locations in the code without tests.
