### PR TITLE
Don't set the Logger field in the nginx_access decoder.

### DIFF
--- a/sandbox/lua/decoders/nginx_access.lua
+++ b/sandbox/lua/decoders/nginx_access.lua
@@ -28,7 +28,7 @@
 --  Hostname: trink-x230
 --  Pid: 0
 --  UUID: 8e414f01-9d7f-4a48-a5e1-ae92e5954df5
---  Logger: nginx.access
+--  Logger: FxaNginxAccessInput
 --  Payload:
 --  EnvVersion:
 --  Severity: 0
@@ -50,7 +50,6 @@ local msg_type = read_config("type")
 
 local msg = {
 Timestamp = nil,
-Logger = "nginx.access",
 Type = msg_type,
 Fields = nil
 }


### PR DESCRIPTION
The LogfileInput replacement (LogstreamerInput) better manages the field
and the decoder was clobbering the more useful value (by not setting
Logger the existing value is preserved).
