### PR TITLE
Added SIGTERM handling (same behavior as SIGINT)

### DIFF
--- a/pipeline/pipeline_runner.go
+++ b/pipeline/pipeline_runner.go
@@ -229,7 +229,7 @@ func Run(config *PipelineConfig) {
 	}
 
 	// wait for sigint
-	signal.Notify(globals.sigChan, syscall.SIGINT, syscall.SIGHUP, SIGUSR1)
+	signal.Notify(globals.sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP, SIGUSR1)
 
 	for !globals.Stopping {
 		select {
@@ -240,7 +240,7 @@ func Run(config *PipelineConfig) {
 				if err := notify.Post(RELOAD, nil); err != nil {
 					log.Println("Error sending reload event: ", err)
 				}
-			case syscall.SIGINT:
+			case syscall.SIGINT, syscall.SIGTERM:
 				log.Println("Shutdown initiated.")
 				globals.Stopping = true
 			case SIGUSR1:


### PR DESCRIPTION
As per http://en.wikipedia.org/wiki/Unix_signal:
SIGTERM
The SIGTERM signal is sent to a process to request its termination. Unlike the SIGKILL signal, it can be caught and interpreted or ignored by the process. This allows the process to perform nice termination releasing resources and saving state if appropriate. It should be noted that SIGINT is nearly identical to SIGTERM.
