### PR TITLE
Map syslog Fields[msg] to the message Payload

### DIFF
--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -19,7 +19,7 @@ if(INCLUDE_SANDBOX)
     externalproject_add(
         ${SANDBOX_PACKAGE}
         GIT_REPOSITORY https://github.com/mozilla-services/lua_sandbox.git
-        GIT_TAG 8c10f839f7a9d5af52e6472e9e29d8c273a2dedc
+        GIT_TAG 0feb8e4cda4a9cab01729e251bdc7710b28b8c78
         CMAKE_ARGS ${SANDBOX_ARGS}
         INSTALL_DIR ${PROJECT_PATH}
     )

--- a/sandbox/lua/decoders/rsyslog.lua
+++ b/sandbox/lua/decoders/rsyslog.lua
@@ -34,11 +34,10 @@ Config
 :Pid: 0
 :UUID: e0eef205-0b64-41e8-a307-5772b05e16c1
 :Logger: RsyslogInput
-:Payload:
+:Payload: "imklog 5.8.6, log source = /proc/kmsg started."
 :EnvVersion:
 :Severity: 7
 :Fields:
-    | name:"msg" value_string:"imklog 5.8.6, log source = /proc/kmsg started."
     | name:"syslogtag" value_string:"kernel:"]
 --]]
 
@@ -47,10 +46,11 @@ local syslog = require "syslog"
 local template = read_config("template")
 
 local msg = {
-Timestamp = nil,
-Hostname = nil,
-Severity = nil,
-Fields = nil
+Timestamp   = nil,
+Hostname    = nil,
+Payload     = nil,
+Severity    = nil,
+Fields      = nil
 }
 
 local grammar = syslog.build_rsyslog_grammar(template)
@@ -82,6 +82,9 @@ function process_message ()
     msg.Hostname = fields.hostname or fields.source
     fields.hostname = nil
     fields.source = nil
+
+    msg.Payload = fields.msg
+    fields.msg = nil
 
     msg.Fields = fields
     inject_message(msg)

--- a/sandbox/plugins/sandbox_plugins_test.go
+++ b/sandbox/plugins/sandbox_plugins_test.go
@@ -411,13 +411,10 @@ func DecoderSpec(c gs.Context) {
 
 			c.Expect(pack.Message.GetSeverity(), gs.Equals, int32(4))
 			c.Expect(pack.Message.GetHostname(), gs.Equals, "testhost")
+			c.Expect(pack.Message.GetPayload(), gs.Equals, "imklog 5.8.6, log source = /proc/kmsg started.")
 
 			var ok bool
 			var value interface{}
-			value, ok = pack.Message.GetFieldValue("msg")
-			c.Expect(ok, gs.Equals, true)
-			c.Expect(value, gs.Equals, "imklog 5.8.6, log source = /proc/kmsg started.")
-
 			value, ok = pack.Message.GetFieldValue("syslogtag")
 			c.Expect(ok, gs.Equals, true)
 			c.Expect(value, gs.Equals, "kernel:")


### PR DESCRIPTION
- Allows the syslog message contents to be processed in a
  multi-decoder configuration.
- Pull in the sandbox changes to allow parsing of an empty msg
  string in the TraditionalFileFormat template.
