### PR TITLE
Properly fix issue with checking for a newer file.

### DIFF
--- a/logstreamer/reader.go
+++ b/logstreamer/reader.go
@@ -447,6 +447,7 @@ func (l *Logstream) readBytes(p []byte) (n int, err error) {
 	// If we had an EOF last time, we check for a new file before trying
 	// to read again
 	if l.priorEOF {
+		l.position.GenerateHash()
 		newerFilename, ok = l.NewerFileAvailable()
 	}
 
@@ -464,9 +465,6 @@ func (l *Logstream) readBytes(p []byte) (n int, err error) {
 
 	// Return now if we didn't get an error
 	if err == nil {
-		if l.priorEOF && n > 0 {
-			l.priorEOF = false
-		}
 		return
 	}
 


### PR DESCRIPTION
Issue was that the hash mismatch checked the hash based off the _current_ seek position, but the hash was from the last time it was saved (which might not be exactly where the seek position is). Therefore we should update the hash anytime we compare for a newer file.
