### PR TITLE
Explicitly set t.connection to nil when the connection fails

### DIFF
--- a/plugins/tcp/tcp_output.go
+++ b/plugins/tcp/tcp_output.go
@@ -237,6 +237,9 @@ func (t *TcpOutput) sendRecord(record []byte) (err error) {
 	var n int
 	if t.connection == nil {
 		if err = t.connect(); err != nil {
+			// Explicitly set t.connection to nil b/c Go, see
+			// http://golang.org/doc/faq#nil_error.
+			t.connection = nil
 			return
 		}
 	}


### PR DESCRIPTION
Resolves #706.
