### PR TITLE
add tls.Config params

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -77,6 +77,11 @@ Bug Handling
 
 Features
 --------
+* TLS Listeners can specify a 'client_cafile' which limits the CAs that a
+  client cert can be chained to. This provides a mechanism for TLS Client AUTH.
+
+* TLS Senders can specify a 'root_cafile' which limits the CAs that a
+  server cert can be chained to. This provides a mechanims for TLS Server AUTH.
 
 * The SandboxManagerFilter can now control the sandbox usage limits (issue #95)
 

--- a/docs/source/tls.rst
+++ b/docs/source/tls.rst
@@ -102,6 +102,16 @@ TLS configuration settings
 
 	Defaults to TLS12.
 
+- client_cafile (string, server):
+	File for server to authenticate client TLS handshake. Any client certs recieved by server
+	must be chained to a CA found in this PEM file.
+    
+	Has no effect when NoClientCert is set.
+
+- root_cafile (string, client):
+	File for client to authenticate server TLS handshake. Any server certs recieved by client
+	must be must be chained to a CA found in this PEM file.
+
 Sample TLS configuration
 ========================
 

--- a/plugins/tcp/tls_test.go
+++ b/plugins/tcp/tls_test.go
@@ -108,5 +108,20 @@ func TlsSpec(c gs.Context) {
 			c.Expect(err, gs.Not(gs.IsNil))
 			c.Expect(err.Error(), gs.Equals, "Invalid cipher string: foo")
 		})
+
+		c.Specify("root_cafile loads CA", func() {
+			tomlConf.ClientCAs = "./testsupport/cert.pem"
+			goConf, err = CreateGoTlsConfig(tomlConf)
+			c.Expect(err, gs.IsNil)
+			c.Expect(len(goConf.ClientCAs.Subjects()), gs.Equals, 1)
+		})
+
+		c.Specify("client_cafile loads CA", func() {
+			tomlConf.RootCAs = "./testsupport/cert.pem"
+			goConf, err = CreateGoTlsConfig(tomlConf)
+			c.Expect(err, gs.IsNil)
+			c.Expect(len(goConf.RootCAs.Subjects()), gs.Equals, 1)
+		})
+
 	})
 }


### PR DESCRIPTION
- ClientCAs
  allows the server to restrict client submitted certs to specific CAs
- RootCAs
  allows the client to restrict what certs the server responds
