### PR TITLE
Ensure alignment of 64 bit integers on 32 bit systems

### DIFF
--- a/cmd/heka-flood/main.go
+++ b/cmd/heka-flood/main.go
@@ -48,16 +48,16 @@ import (
 )
 
 type FloodTest struct {
+	NumMessages          uint64                       `toml:"num_messages"`
+	StaticMessageSize    uint64                       `toml:"static_message_size"`
 	IpAddress            string                       `toml:"ip_address"`
 	Sender               string                       `toml:"sender"`
 	PprofFile            string                       `toml:"pprof_file"`
 	Encoder              string                       `toml:"encoder"`
-	NumMessages          uint64                       `toml:"num_messages"`
 	Signer               message.MessageSigningConfig `toml:"signer"`
 	CorruptPercentage    float64                      `toml:"corrupt_percentage"`
 	SignedPercentage     float64                      `toml:"signed_percentage"`
 	VariableSizeMessages bool                         `toml:"variable_size_messages"`
-	StaticMessageSize    uint64                       `toml:"static_message_size"`
 	AsciiOnly            bool                         `toml:"ascii_only"`
 	UseTls               bool                         `toml:"use_tls"`
 	Tls                  tcp.TlsConfig                `toml:"tls"`

--- a/logstreamer/reader.go
+++ b/logstreamer/reader.go
@@ -27,8 +27,8 @@ import (
 
 // A location in a logstream indicating the farthest that has been read
 type LogstreamLocation struct {
-	Filename     string           `json:"file_name"`
 	SeekPosition int64            `json:"seek"`
+	Filename     string           `json:"file_name"`
 	Hash         string           `json:"last_hash"`
 	JournalPath  string           `json:"-"`
 	lastLine     *ringbuf.Ringbuf `json:"-"`

--- a/pipeline/pipeline_runner.go
+++ b/pipeline/pipeline_runner.go
@@ -36,12 +36,12 @@ const (
 
 // Struct for holding global pipeline config values.
 type GlobalConfigStruct struct {
+	MaxMsgProcessDuration uint64
 	PoolSize              int
 	DecoderPoolSize       int
 	PluginChanSize        int
 	MaxMsgLoops           uint
 	MaxMsgProcessInject   uint
-	MaxMsgProcessDuration uint64
 	MaxMsgTimerInject     uint
 	MaxPackIdle           time.Duration
 	Stopping              bool

--- a/pipeline/router.go
+++ b/pipeline/router.go
@@ -49,13 +49,13 @@ type MessageRouter interface {
 }
 
 type messageRouter struct {
+	processMessageCount int64
 	inChan              chan *PipelinePack
 	addFilterMatcher    chan *MatchRunner
 	removeFilterMatcher chan *MatchRunner
 	removeOutputMatcher chan *MatchRunner
 	fMatchers           []*MatchRunner
 	oMatchers           []*MatchRunner
-	processMessageCount int64
 }
 
 // Creates and returns a (not yet started) Heka message router.
@@ -178,12 +178,12 @@ func (self *messageRouter) Start() {
 // Encapsulates the mechanics of testing messages against a specific plugin's
 // message_matcher value.
 type MatchRunner struct {
+	matchSamples  int64
+	matchDuration int64
 	spec          *message.MatcherSpecification
 	signer        string
 	inChan        chan *PipelinePack
 	pluginRunner  PluginRunner
-	matchSamples  int64
-	matchDuration int64
 	reportLock    sync.Mutex
 }
 

--- a/plugins/file/logfile_input.go
+++ b/plugins/file/logfile_input.go
@@ -157,11 +157,13 @@ func (lw *LogfileInput) Stop() {
 // Handles the actual mechanics of finding, watching, and reading from file
 // system files.
 type FileMonitor struct {
+	seek               int64
+	last_logline_start int64
+
 	// Channel onto which FileMonitor will place PipelinePack objects as the file
 	// is being read.
 	outChan  chan *PipelinePack
 	stopChan chan bool
-	seek     int64
 
 	logfile         string
 	seekJournalPath string
@@ -175,9 +177,8 @@ type FileMonitor struct {
 	pendingMessages []string
 	pendingErrors   []string
 
-	last_logline       string
-	last_logline_start int64
-	resumeFromStart    bool
+	last_logline    string
+	resumeFromStart bool
 
 	parser        StreamParser
 	parseFunction func(fm *FileMonitor, isRotated bool) (bytesRead int64, err error)

--- a/plugins/tcp/tcp_output.go
+++ b/plugins/tcp/tcp_output.go
@@ -35,6 +35,9 @@ import (
 
 // Output plugin that sends messages via TCP using the Heka protocol.
 type TcpOutput struct {
+	processMessageCount int64
+	sentMessageCount    int64
+	readOffset          int64
 	conf                *TcpOutputConfig
 	parser              *MessageProtoParser
 	address             string
@@ -43,14 +46,11 @@ type TcpOutput struct {
 	writeId             uint
 	readFile            *os.File
 	readId              uint
-	readOffset          int64
 	checkpointFilename  string
 	checkpointFile      *os.File
 	queue               string
 	name                string
 	reportLock          sync.Mutex
-	processMessageCount int64
-	sentMessageCount    int64
 }
 
 // ConfigStruct for TcpOutput plugin.

--- a/sandbox/plugins/sandbox_decoder.go
+++ b/sandbox/plugins/sandbox_decoder.go
@@ -33,13 +33,13 @@ import (
 
 // Decoder for converting structured/unstructured data into Heka messages.
 type SandboxDecoder struct {
-	sb                     Sandbox
-	sbc                    *SandboxConfig
-	preservationFile       string
 	processMessageCount    int64
 	processMessageFailures int64
 	processMessageSamples  int64
 	processMessageDuration int64
+	sb                     Sandbox
+	sbc                    *SandboxConfig
+	preservationFile       string
 	reportLock             sync.Mutex
 	sample                 bool
 	err                    error

--- a/sandbox/plugins/sandbox_filter.go
+++ b/sandbox/plugins/sandbox_filter.go
@@ -44,9 +44,6 @@ func fileExists(path string) bool {
 // dynamically loaded through the sandbox manager) maps to exactly one
 // SandboxFilter instance.
 type SandboxFilter struct {
-	sb                     Sandbox
-	sbc                    *SandboxConfig
-	preservationFile       string
 	processMessageCount    int64
 	processMessageFailures int64
 	injectMessageCount     int64
@@ -56,6 +53,9 @@ type SandboxFilter struct {
 	profileMessageDuration int64
 	timerEventSamples      int64
 	timerEventDuration     int64
+	sb                     Sandbox
+	sbc                    *SandboxConfig
+	preservationFile       string
 	reportLock             sync.Mutex
 	name                   string
 }

--- a/sandbox/plugins/sandbox_manager_filter.go
+++ b/sandbox/plugins/sandbox_manager_filter.go
@@ -34,11 +34,11 @@ import (
 // dynamically creates, manages, and destroys sandboxed filter scripts as
 // instructed.
 type SandboxManagerFilter struct {
+	processMessageCount int64
 	maxFilters          int
 	currentFilters      int
 	workingDirectory    string
 	moduleDirectory     string
-	processMessageCount int64
 	memoryLimit         uint
 	instructionLimit    uint
 	outputLimit         uint


### PR DESCRIPTION
Technically this is only required for 64 bit integers being accessed
with the atomic package but it seemed like a good practice to put all
64 bit integers at the beginning of the structure to ensure they are
aligned.

https://code.google.com/p/go/issues/detail?id=6404
