### PR TITLE
Add support for 'missing' as a match key to support ordering on

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,6 +16,15 @@ Features
 Bug Handling
 ------------
 
+* Logstreamer package's NewLogstreamSet function no longer lowercases the
+  match part names when constructing match translation maps since the
+  PopulateMatchParts method doesn't actually expect the names to be
+  lowercased.
+
+* Added support for use of "missing" value in Logstreamer translation maps to
+  allow users to place missing values at the end of the list instead of the
+  beginning (issue #735).
+
 0.5.0 (2014-03-06)
 ==================
 

--- a/docs/source/config/inputs/logstreamer.rst
+++ b/docs/source/config/inputs/logstreamer.rst
@@ -36,9 +36,13 @@ Config:
     usually fine. This interval is in milliseconds.
 - file_match (string):
     Regular expression used to match files located under the
-    ``log_directory``. This regular expression has ``$`` added to the
-    end automatically if not already present, and ``log_directory`` as the
-    prefix.
+    ``log_directory``. This regular expression has ``$`` added to the end
+    automatically if not already present, and ``log_directory`` as the prefix.
+    WARNING: file_match should typically be delimited with single quotes,
+    indicating use of a raw string, rather than double quotes, which require
+    all backslashes to be escaped. For example, `'access\.log'` will work as
+    expected, but `"access\.log"` will not, you would need `"access\\.log"` to
+    achieve the same result.
 - priority (list of strings):
     When using sequential logstreams, the priority is how to sort the logfiles
     in order from oldest to newest.

--- a/docs/source/pluginconfig/logstreamer.rst
+++ b/docs/source/pluginconfig/logstreamer.rst
@@ -11,19 +11,19 @@ sequential user-defined order, differentiating multiple logstreams
 found in a search based on a user-defined differentiator. This plugin
 supercedes the LogfileInput and the LogfileDirectoryInput.
 
-A "log stream" is a single, linear data stream that is spread across
+A "logstream" is a single, linear data stream that is spread across
 one or more sequential log files. For instance, an Apache or nginx
-server typically generates two log streams for each domain: an access
+server typically generates two logstreams for each domain: an access
 log and an error log. Each stream might be written to a single log file
 that is periodically truncated (ick!) or rotated (better), with some
 number of historical versions being kept (e.g. access-example.com.log,
 access-example.com.log.0, access-example.com.log.1, etc.). Or, better
 yet, the server might periodically create new timestamped files so that
-the 'tip' of the log stream jumps from file to file (e.g. access-
+the 'tip' of the logstream jumps from file to file (e.g. access-
 example.com-2014.01.28.log, access-example.com-2014.01.27.log, access-
 example.com-2014.01.26.log, etc.). The job of Heka's Logstreamer plugin
 is to understand the file naming and ordering conventions for a single
-type of log stream (e.g. "all of the nginx server's domain access
+type of logstream (e.g. "all of the nginx server's domain access
 logs"), and to use that to watch the specified directories and load the
 right files in the right order. The plugin will also track its
 location in the stream so it can resume from where it left off after a
@@ -61,6 +61,15 @@ configuration for such a case looks like:
     type = "LogstreamerInput"
     log_directory = "/var/log"
     file_match = 'system\.log'
+
+.. note::
+
+    The ``file_match`` config value above is delimited with single quotes
+    instead of double quotes (i.e. `'system\.log'` vs. `"system\.log"`)
+    because single quotes indicate raw strings that do not require backslashes
+    to be escaped. If you use double quotes around your regular expressions
+    you'll need to escape backslashes by doubling them up, e.g.
+    `"system\\.log"`.
 
 We start with the highest directory to start scanning for files under, in
 this case ``/var/log``. Then the files under that directory (recursively
@@ -132,7 +141,8 @@ Or a combination of them?
     /var/log/nginx/2014/08/access.log.2
     /var/log/nginx/2014/08/access.log.3
 
-(Hopefully your setup isn't worse than any of these... but even if it is then Logstreamer can handle it.)
+(Hopefully your setup isn't worse than any of these... but even if it is then
+Logstreamer can handle it.)
 
 Handling a single access log that is sequential and rotated (the first
 example) can be tricky. The second case where rotation doesn't occur
@@ -236,8 +246,8 @@ separate logstream.
 
 .. seealso:: :ref:`Full set of configuration options <config_logstreamer_input>`
 
-Custom String Mappings
-======================
+String-based Order Mappings
+===========================
 
 In the standard configurations above, the assumption has been that any
 part matched for sorting will be digit(s). This is because the
@@ -334,12 +344,68 @@ Now to supply the important mapping of how to translate ``Month`` and
 
 .. note::
 
-    The keys and matched values used are all lowercased before
-    comparison.
+    The matched values used are all lowercased before comparison, so 'lunes'
+    in the example above would match captured values of 'lunes', 'Lunes', and
+    'LuNeS' equivalently.
 
 We left off the rest of the month names and day names not used for
 example purposes. Note that if you prefer the week to begin on a
 Saturday instead of Monday you can configure it with a custom mapping.
+
+Mappings with Missing Values
+----------------------------
+
+In the examples above, the years and months were embedded in the file
+path as directory names, but what if the date was embedded into the
+filenames themselves, with a file naming schema like so?
+
+.. code-block::
+
+    /var/log/nginx/sally.com/access.log
+    /var/log/nginx/sally.com/access-20140803.log
+    /var/log/nginx/sally.com/access-20140804.log
+    /var/log/nginx/sally.com/access-20140805.log
+    /var/log/nginx/sally.com/access-20140806.log
+    /var/log/nginx/sally.com/access-20140807.log
+    /var/log/nginx/sally.com/access-20140808.log
+
+Notice how the currently active log file contains no date information at all.
+As long as you construct your file_match regex correctly this will be fine,
+Logstreamer will capture all of the files and won't complain about entries
+that are missing the match portions. The following config would work to
+capture all of these files:
+
+.. code-block:: ini
+
+    [accesslogs]
+    type = "LogstreamerInput"
+    log_directory = "/var/log/nginx"
+    file_match = '(?P<Domain>[^/]+)/access-?(?P<Year>\d4)(?P<Month>\d2)(?P<Day>\d2)\.log'
+    priority = ["Year", "Month", "Day"]
+    differentiator = ["nginx-", "Domain", "-access"]
+
+This works to match all of the files because match groups are implicitly
+optional and we explicitly made the hyphen separator optional by following it
+with a question mark (i.e. `-?`). We still have a problem, however. Heka will
+automatically assign a missing match a sort value of -1. Because we're sorting
+by date values, which sort naturally in ascending order, the -1 value will
+come before every other value, it will be considered the oldest file in the
+stream. This is clearly incorrect, since the currently active file is actually
+the newest file in the stream.
+
+It is possible to fix this by using a custom translation map to explicitly
+associate a sort index with the 'missing' value, like so:
+
+.. code-block:: ini
+
+    [accesslogs.translation.Year]
+    missing = 9999
+
+Note that if you create a translation map with only one key, that key *must*
+be 'missing'. It's possible to use the 'missing' value in a translation map
+that also contains other keys, but if you have any other key in the map you
+must include *all* possible match values, or else Heka will raise an error
+when it finds a match value that can't be converted.
 
 Verifying Settings
 ==================

--- a/logstreamer/filehandling.go
+++ b/logstreamer/filehandling.go
@@ -4,18 +4,18 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 # The Initial Developer of the Original Code is the Mozilla Foundation.
-# Portions created by the Initial Developer are Copyright (C) 2012
+# Portions created by the Initial Developer are Copyright (C) 2014
 # the Initial Developer. All Rights Reserved.
 #
 # Contributor(s):
 #   Ben Bangert (bbangert@mozilla.com)
+#   Rob Miller (rmiller@mozilla.com)
 #
 # ***** END LICENSE BLOCK *****/
 
 package logstreamer
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -110,9 +110,14 @@ type Logfile struct {
 // Populate the MatchParts of a Logfile supplied with the sub-expression names,
 // and the match parts out of the regex along with a translation map to derive
 // sorting ints from
-func (l *Logfile) PopulateMatchParts(subexpNames, matches []string, translation SubmatchTranslationMap) error {
-	var score int
-	var ok bool
+func (l *Logfile) PopulateMatchParts(subexpNames, matches []string,
+	translation SubmatchTranslationMap) error {
+
+	var (
+		score  int
+		ok     bool
+		submap MatchTranslationMap
+	)
 	if l.MatchParts == nil {
 		l.MatchParts = make(map[string]int)
 	}
@@ -124,25 +129,53 @@ func (l *Logfile) PopulateMatchParts(subexpNames, matches []string, translation 
 		// Store the raw string
 		l.StringMatchParts[name] = matchValue
 
+		if matchValue == "" {
+			matchValue = "missing"
+		}
 		lowerValue := strings.ToLower(matchValue)
 		score = -1
 		if name == "" {
 			continue
 		}
+
+		// Warning: nested ifs ahead. A MatchTranslationMap has to cover every
+		// possible value *or* contain only the "missing" value or else it
+		// will raise an error.
 		if name == "MonthName" {
 			if score, ok = MonthLookup[lowerValue]; !ok {
-				return errors.New("Unable to locate month name: " + matchValue)
+				return fmt.Errorf("Unable to locate month name: %s", matchValue)
 			}
 		} else if name == "DayName" {
 			if score, ok = DayLookup[lowerValue]; !ok {
-				return errors.New("Unable to locate day name : " + matchValue)
+				return fmt.Errorf("Unable to locate day name: %s", matchValue)
 			}
-		} else if submap, ok := translation[name]; ok {
+		} else if submap, ok = translation[name]; ok && len(submap) > 1 {
 			if score, ok = submap[lowerValue]; !ok {
-				return errors.New("Unable to locate value: (" + matchValue + ") in translation map: " + name)
+				return fmt.Errorf("Value '%s' not found in translation map '%s'.",
+					matchValue, name)
 			}
-		} else if digitRegex.MatchString(matchValue) {
-			score, _ = strconv.Atoi(matchValue)
+		} else if ok {
+			// 'ok' value falls through from above, i.e. submap exists and has
+			// 'len > 1.
+			if lowerValue == "missing" {
+				if score, ok = submap["missing"]; !ok {
+					// This shouldn't happen, config validation should prevent
+					// a translation map of len 1 that contains anything other
+					// than "missing".
+					score = -1
+					ok = true
+				}
+			} else {
+				// We're not the "missing" value, '!ok' signals that we should
+				// convert from integer if possible.
+				ok = false
+			}
+		}
+		if !ok {
+			// We didn't match, try to convert to an int.
+			if digitRegex.MatchString(matchValue) {
+				score, _ = strconv.Atoi(matchValue)
+			}
 		}
 		l.MatchParts[name] = score
 	}
@@ -169,7 +202,9 @@ func (l Logfiles) IndexOf(s string) int {
 
 // Provided the fileMatch regexp and translation map, populate all the Logfile
 // matchparts for use in sorting.
-func (l Logfiles) PopulateMatchParts(fileMatch *regexp.Regexp, translation SubmatchTranslationMap) error {
+func (l Logfiles) PopulateMatchParts(fileMatch *regexp.Regexp,
+	translation SubmatchTranslationMap) error {
+
 	errorlist := NewMultipleError()
 	subexpNames := fileMatch.SubexpNames()
 	for _, logfile := range l {
@@ -333,14 +368,14 @@ type LogstreamSet struct {
 
 func NewLogstreamSet(sortPattern *SortPattern, oldest time.Duration,
 	logRoot, journalRoot string) *LogstreamSet {
-	// Lowercase all the keys
+	// Lowercase the actual matching keys.
 	newTranslation := make(SubmatchTranslationMap)
 	for key, val := range sortPattern.Translation {
 		newValMap := make(MatchTranslationMap)
 		for matchPart, intVal := range val {
 			newValMap[strings.ToLower(matchPart)] = intVal
 		}
-		newTranslation[strings.ToLower(key)] = newValMap
+		newTranslation[key] = newValMap
 	}
 	sortPattern.Translation = newTranslation
 

--- a/plugins/logstreamer/logstreamer_input.go
+++ b/plugins/logstreamer/logstreamer_input.go
@@ -4,11 +4,12 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 # The Initial Developer of the Original Code is the Mozilla Foundation.
-# Portions created by the Initial Developer are Copyright (C) 2012
+# Portions created by the Initial Developer are Copyright (C) 2014
 # the Initial Developer. All Rights Reserved.
 #
 # Contributor(s):
 #   Ben Bangert (bbangert@mozilla.com)
+#   Rob Miller (rmiller@mozilla.com)
 #
 # ***** END LICENSE BLOCK *****/
 package logstreamer
@@ -120,6 +121,16 @@ func (li *LogstreamerInput) Init(config interface{}) (err error) {
 	// If no differentiator is present than we use the plugin
 	if len(conf.Differentiator) == 0 {
 		conf.Differentiator = []string{li.pluginName}
+	}
+
+	for name, submap := range conf.Translation {
+		if len(submap) == 1 {
+			if _, ok := submap["missing"]; !ok {
+				err = fmt.Errorf("A translation map with one entry ('%s') must be "+
+					"specifying a 'missing' key.", name)
+				return
+			}
+		}
 	}
 
 	// Create the main sort pattern

--- a/plugins/logstreamer/logstreamer_input_test.go
+++ b/plugins/logstreamer/logstreamer_input_test.go
@@ -4,11 +4,12 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 # The Initial Developer of the Original Code is the Mozilla Foundation.
-# Portions created by the Initial Developer are Copyright (C) 2012
+# Portions created by the Initial Developer are Copyright (C) 2014
 # the Initial Developer. All Rights Reserved.
 #
 # Contributor(s):
 #   Ben Bangert (bbangert@mozilla.com)
+#   Rob Miller (rmiller@mozilla.com)
 #
 # ***** END LICENSE BLOCK *****/
 
@@ -16,6 +17,7 @@ package logstreamer
 
 import (
 	"code.google.com/p/gomock/gomock"
+	ls "github.com/mozilla-services/heka/logstreamer"
 	. "github.com/mozilla-services/heka/pipeline"
 	pipeline_ts "github.com/mozilla-services/heka/pipeline/testsupport"
 	"github.com/mozilla-services/heka/pipelinemock"
@@ -62,7 +64,7 @@ func LogstreamerInputSpec(c gs.Context) {
 	ith.PackSupply = make(chan *PipelinePack, 1)
 	ith.DecodeChan = make(chan *PipelinePack)
 
-	c.Specify("A LogFileInput", func() {
+	c.Specify("A LogstreamerInput", func() {
 		tmpDir, tmpErr := ioutil.TempDir("", "hekad-tests-")
 		c.Expect(tmpErr, gs.Equals, nil)
 		origBaseDir := Globals().BaseDir
@@ -72,61 +74,85 @@ func LogstreamerInputSpec(c gs.Context) {
 			tmpErr = os.RemoveAll(tmpDir)
 			c.Expect(tmpErr, gs.IsNil)
 		}()
-		lfInput := new(LogstreamerInput)
-		lfiConfig := lfInput.ConfigStruct().(*LogstreamerInputConfig)
-		lfiConfig.LogDirectory = dirPath
-		lfiConfig.FileMatch = `file.log(\.?)(?P<Seq>\d+)?`
-		lfiConfig.Differentiator = []string{"logfile"}
-		lfiConfig.Priority = []string{"^Seq"}
-		lfiConfig.Decoder = "decoder-name"
-		err := lfInput.Init(lfiConfig)
-		c.Expect(err, gs.IsNil)
-		c.Expect(len(lfInput.plugins), gs.Equals, 1)
-		mockDecoderRunner := pipelinemock.NewMockDecoderRunner(ctrl)
+		lsInput := new(LogstreamerInput)
+		lsiConfig := lsInput.ConfigStruct().(*LogstreamerInputConfig)
+		lsiConfig.LogDirectory = dirPath
+		lsiConfig.FileMatch = `file.log(\.?)(?P<Seq>\d+)?`
+		lsiConfig.Differentiator = []string{"logfile"}
+		lsiConfig.Priority = []string{"^Seq"}
+		lsiConfig.Decoder = "decoder-name"
 
-		// Create pool of packs.
-		numLines := 5 // # of lines in the log file we're parsing.
-		packs := make([]*PipelinePack, numLines)
-		ith.PackSupply = make(chan *PipelinePack, numLines)
-		for i := 0; i < numLines; i++ {
-			packs[i] = NewPipelinePack(ith.PackSupply)
-			ith.PackSupply <- packs[i]
-		}
+		c.Specify("w/ no tranlation map", func() {
+			err := lsInput.Init(lsiConfig)
+			c.Expect(err, gs.IsNil)
+			c.Expect(len(lsInput.plugins), gs.Equals, 1)
+			mockDecoderRunner := pipelinemock.NewMockDecoderRunner(ctrl)
 
-		c.Specify("reads a log file", func() {
-			// Expect InputRunner calls to get InChan and inject outgoing msgs
-			ith.MockInputRunner.EXPECT().LogError(gomock.Any()).AnyTimes()
-			ith.MockInputRunner.EXPECT().LogMessage(gomock.Any()).AnyTimes()
-			ith.MockInputRunner.EXPECT().InChan().Return(ith.PackSupply).Times(numLines)
-			// Expect calls to get decoder and decode each message. Since the
-			// decoding is a no-op, the message payload will be the log file
-			// line, unchanged.
-			pbcall := ith.MockHelper.EXPECT().DecoderRunner(lfiConfig.Decoder, "-"+lfiConfig.Decoder)
-			pbcall.Return(mockDecoderRunner, true)
-			decodeCall := mockDecoderRunner.EXPECT().InChan().Times(numLines)
-			decodeCall.Return(ith.DecodeChan)
-
-			go func() {
-				err = lfInput.Run(ith.MockInputRunner, ith.MockHelper)
-				c.Expect(err, gs.IsNil)
-			}()
-
-			d, _ := time.ParseDuration("5s")
-			timeout := time.After(d)
-			timed := false
-			for x := 0; x < numLines; x++ {
-				select {
-				case <-ith.DecodeChan:
-				case <-timeout:
-					timed = true
-					x += numLines
-				}
-				// Free up the scheduler while we wait for the log file lines
-				// to be processed.
-				runtime.Gosched()
+			// Create pool of packs.
+			numLines := 5 // # of lines in the log file we're parsing.
+			packs := make([]*PipelinePack, numLines)
+			ith.PackSupply = make(chan *PipelinePack, numLines)
+			for i := 0; i < numLines; i++ {
+				packs[i] = NewPipelinePack(ith.PackSupply)
+				ith.PackSupply <- packs[i]
 			}
-			lfInput.Stop()
-			c.Expect(timed, gs.Equals, false)
+
+			c.Specify("reads a log file", func() {
+				// Expect InputRunner calls to get InChan and inject outgoing msgs
+				ith.MockInputRunner.EXPECT().LogError(gomock.Any()).AnyTimes()
+				ith.MockInputRunner.EXPECT().LogMessage(gomock.Any()).AnyTimes()
+				ith.MockInputRunner.EXPECT().InChan().Return(ith.PackSupply).Times(numLines)
+				// Expect calls to get decoder and decode each message. Since the
+				// decoding is a no-op, the message payload will be the log file
+				// line, unchanged.
+				pbcall := ith.MockHelper.EXPECT().DecoderRunner(lsiConfig.Decoder,
+					"-"+lsiConfig.Decoder)
+				pbcall.Return(mockDecoderRunner, true)
+				decodeCall := mockDecoderRunner.EXPECT().InChan().Times(numLines)
+				decodeCall.Return(ith.DecodeChan)
+
+				go func() {
+					err = lsInput.Run(ith.MockInputRunner, ith.MockHelper)
+					c.Expect(err, gs.IsNil)
+				}()
+
+				d, _ := time.ParseDuration("5s")
+				timeout := time.After(d)
+				timed := false
+				for x := 0; x < numLines; x++ {
+					select {
+					case <-ith.DecodeChan:
+					case <-timeout:
+						timed = true
+						x += numLines
+					}
+					// Free up the scheduler while we wait for the log file lines
+					// to be processed.
+					runtime.Gosched()
+				}
+				lsInput.Stop()
+				c.Expect(timed, gs.Equals, false)
+			})
+		})
+
+		c.Specify("with a translation map", func() {
+			lsiConfig.Translation = make(ls.SubmatchTranslationMap)
+			lsiConfig.Translation["Seq"] = make(ls.MatchTranslationMap)
+
+			c.Specify("allows len 1 translation map for 'missing'", func() {
+				lsiConfig.Translation["Seq"]["missing"] = 9999
+				err := lsInput.Init(lsiConfig)
+				c.Expect(err, gs.IsNil)
+			})
+
+			c.Specify("doesn't allow len 1 map for other keys", func() {
+				lsiConfig.Translation["Seq"]["missin"] = 9999
+				err := lsInput.Init(lsiConfig)
+				c.Expect(err, gs.Not(gs.IsNil))
+				c.Expect(err.Error(), gs.Equals,
+					"A translation map with one entry ('Seq') must be specifying a "+
+						"'missing' key.")
+			})
 		})
 	})
 }


### PR DESCRIPTION
missing match values, and fix a bug w.r.t. lowercasing match variable
names. Resolves #735.
