### PR TITLE
Add AMQPS TLS config support to AMQP plugins

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -67,6 +67,9 @@ Features
 
 * Add QueueTTL option to AMQPInput to allow specifying message expiration.
 
+* Added optional tls sub-section to AMQPInput and AMQPOutput for configuring
+  AMQPS TLS settings.
+
 0.5.2 (2014-05-16)
 ==================
 

--- a/docs/source/config/inputs/amqp.rst
+++ b/docs/source/config/inputs/amqp.rst
@@ -49,6 +49,13 @@ Config:
     AMQPOutput in another Heka process then this should be a
     :ref:`config_protobuf_decoder` instance.
 
+.. versionadded:: 0.6
+
+- tls (TlsConfig):
+    An optional sub-section that specifies the settings to be used for any
+    SSL/TLS encryption. This will only have any impact if `URL` uses the
+    `AMQPS` URI scheme. See :ref:`tls`.
+
 Since many of these parameters have sane defaults, a minimal configuration to
 consume serialized messages would look like:
 

--- a/docs/source/config/outputs/amqp.rst
+++ b/docs/source/config/outputs/amqp.rst
@@ -37,6 +37,13 @@ Config:
 - Encoder (string)
     Default to "ProtobufEncoder".
 
+.. versionadded:: 0.6
+
+- tls (TlsConfig):
+    An optional sub-section that specifies the settings to be used for any
+    SSL/TLS encryption. This will only have any impact if `URL` uses the
+    `AMQPS` URI scheme. See :ref:`tls`.
+
 Example (that sends log lines from the logger):
 
 .. code-block:: ini

--- a/plugins/amqp/amqp_test.go
+++ b/plugins/amqp/amqp_test.go
@@ -57,7 +57,7 @@ func AMQPPluginSpec(c gs.Context) {
 
 	// Setup the mock amqpHub with the mock chan return
 	aqh := NewMockAMQPConnectionHub(ctrl)
-	aqh.EXPECT().GetChannel("").Return(mch, ug, cg, nil)
+	aqh.EXPECT().GetChannel("", AMQPDialer{}).Return(mch, ug, cg, nil)
 	var oldHub AMQPConnectionHub
 	oldHub = amqpHub
 	amqpHub = aqh


### PR DESCRIPTION
Adds an optional `tls` subsection to AMQP plugins much akin to other inputs and outputs that support TLS. This is useful e.g. if your AMQP broker is set to verify client certificates with `{verify,verify_peer}` and `{fail_if_no_peer_cert,true}` and as such Heka needs to present a client certificate.
