### PR TITLE
Fix panic when no MultiDecoder 'order' is set

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,6 +17,9 @@ Bug Handling
 
 * Fix the SandboxFilter ReportMsg panic on termination/shutdown (issue #816)
 
+* MultiDecoder with no 'order' set now fails on init instead of panicing on
+  first message.
+
 Features
 --------
 

--- a/docs/source/config/decoders/multi.rst
+++ b/docs/source/config/decoders/multi.rst
@@ -15,7 +15,6 @@ Config:
 
 - order (list of strings):
     PipelinePack objects will be passed in order to each decoder in this list.
-    Default is an empty list.
 
 - log_sub_errors (bool):
     If true, the DecoderRunner will log the errors returned whenever a

--- a/pipeline/multidecoder.go
+++ b/pipeline/multidecoder.go
@@ -114,6 +114,10 @@ func (md *MultiDecoder) Init(config interface{}) (err error) {
 		md.Decoders[name] = decoder
 	}
 
+	if len(md.Config.Order) == 0 {
+		return fmt.Errorf("An order must be specified.")
+	}
+
 	md.ordered = make([]Decoder, len(md.Config.Order))
 	for i, name := range md.Config.Order {
 		if decoder, ok = md.Decoders[name]; !ok {

--- a/plugins/payload/multidecoder_test.go
+++ b/plugins/payload/multidecoder_test.go
@@ -129,6 +129,14 @@ func MultiDecoderSpec(c gospec.Context) {
 			c.Expect(subRunner.Decoder(), gs.Equals, sub)
 		})
 
+		c.Specify("fails to init with no order set", func() {
+			conf.Order = []string{}
+			err := decoder.Init(conf)
+			c.Expect(err.Error(), gs.Equals, "An order must be specified.")
+
+			dRunner.LogError(errors.New("foo"))
+		})
+
 		c.Specify("with multiple registered decoders", func() {
 			conf.Subs["StartsWithS"] = make(map[string]interface{}, 0)
 			withS := conf.Subs["StartsWithS"].(map[string]interface{})


### PR DESCRIPTION
MultiDecoder.getDecodedPacks assumes at least one item in chain, which
is built from order config field.

Updated docs to reflect 'order' being required.
