### PR TITLE
fix panic in LogstreamerInput on Windows

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,6 +23,8 @@ Bug Handling
 * Pull in a new lua_sandbox to fix JSON encoding of empty strings in the 
 sandbox plugin output() call.
 
+* Escape regexp meta characters (notably '\') to prevent a panic in the LogstreamerInput on Windows
+
 0.5.1 (2014-03-18)
 ==================
 

--- a/logstreamer/filehandling.go
+++ b/logstreamer/filehandling.go
@@ -366,6 +366,15 @@ type LogstreamSet struct {
 	fileMatch      *regexp.Regexp
 }
 
+// append a path separator if needed and escape regexp meta characters
+func fileMatchRegexp(logRoot, fileMatch string) *regexp.Regexp {
+	if !os.IsPathSeparator(logRoot[len(logRoot)-1]) && !os.IsPathSeparator(fileMatch[0]) {
+		logRoot += string(os.PathSeparator)
+	}
+
+	return regexp.MustCompile("^" + regexp.QuoteMeta(logRoot) + fileMatch)
+}
+
 func NewLogstreamSet(sortPattern *SortPattern, oldest time.Duration,
 	logRoot, journalRoot string) *LogstreamSet {
 	// Lowercase the actual matching keys.
@@ -386,7 +395,7 @@ func NewLogstreamSet(sortPattern *SortPattern, oldest time.Duration,
 		logRoot:        logRoot,
 		journalRoot:    journalRoot,
 		logstreamMutex: new(sync.RWMutex),
-		fileMatch:      regexp.MustCompile("^" + filepath.Join(logRoot, sortPattern.FileMatch)),
+		fileMatch:      fileMatchRegexp(logRoot, sortPattern.FileMatch),
 	}
 }
 


### PR DESCRIPTION
With this configuration on Windows

```
[ZST Request Log]
type = "LogstreamerInput"
log_directory = "D:/NSX/"
file_match = "zst_requests.log"
```

I get the following panic:

```
panic: regexp: Compile(`^D:\NSX\zst_requests.log$`): error parsing regexp: invalid escape sequence: `\N`
```

This pull request escapes the Windows backslashes (and additionally: any other regexp meta characters) in the `log_directory` to create a valid regexp for the `LogstreamerInput`
