### PR TITLE
Don't set RegexpParser delimiter unless one is actually specified.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,10 +4,14 @@
 Bug Handling
 ------------
 
+* Fixed TcpInput so it will only override the default delimiter for a
+  RegexpParser if a delimiter is specified in the config.
+
 * Fix the FileOutput panic when HUP'ed.  Modified the CheckWritePermission
   utility function to use a unique filename for each check. (issue #808)
 
-* Terminated plugins are now removed from the SandboxManager quota (issue #774).
+* Terminated plugins are now removed from the SandboxManager quota (issue
+  #774).
 
 * Fixed SIGUSR1 triggered text report to stdout to work with updated
   heka.all-report JSON data structure (issue #762).
@@ -20,8 +24,8 @@ Bug Handling
 
 * The cbufd_host_aggregator filter now properly reclaims expired hosts.
 
-* Pull in a new lua_sandbox to fix JSON encoding of empty strings in the 
-sandbox plugin output() call.
+* Pull in a new lua_sandbox to fix JSON encoding of empty strings in the
+  sandbox plugin output() call.
 
 0.5.1 (2014-03-18)
 ==================

--- a/plugins/tcp/tcp_input.go
+++ b/plugins/tcp/tcp_input.go
@@ -91,8 +91,10 @@ func (t *TcpInput) Init(config interface{}) error {
 		}
 	} else if t.config.ParserType == "regexp" {
 		rp := NewRegexpParser() // temporary parser to test the config
-		if err = rp.SetDelimiter(t.config.Delimiter); err != nil {
-			return err
+		if len(t.config.Delimiter) > 0 {
+			if err = rp.SetDelimiter(t.config.Delimiter); err != nil {
+				return err
+			}
 		}
 		if err = rp.SetDelimiterLocation(t.config.DelimiterLocation); err != nil {
 			return err
@@ -156,7 +158,9 @@ func (t *TcpInput) handleConnection(conn net.Conn) {
 		rp := NewRegexpParser()
 		parser = rp
 		parseFunction = NetworkPayloadParser
-		rp.SetDelimiter(t.config.Delimiter)
+		if len(t.config.Delimiter) > 0 {
+			rp.SetDelimiter(t.config.Delimiter)
+		}
 		rp.SetDelimiterLocation(t.config.DelimiterLocation)
 	} else if t.config.ParserType == "token" {
 		tp := NewTokenParser()

--- a/plugins/tcp/tcp_input_test.go
+++ b/plugins/tcp/tcp_input_test.go
@@ -273,11 +273,16 @@ func TcpInputSpec(c gs.Context) {
 
 	c.Specify("A TcpInput regexp parser", func() {
 		ith.MockInputRunner.EXPECT().Name().Return("TcpInput")
-		tcpInput := TcpInput{}
-		err := tcpInput.Init(&TcpInputConfig{Net: "tcp", Address: ith.AddrStr,
+
+		config := &TcpInputConfig{
+			Net:        "tcp",
+			Address:    ith.AddrStr,
 			Decoder:    "RegexpDecoder",
 			ParserType: "regexp",
-			Delimiter:  "\n"})
+		}
+
+		tcpInput := TcpInput{}
+		err := tcpInput.Init(config)
 		c.Assume(err, gs.IsNil)
 		realListener := tcpInput.listener
 		c.Expect(realListener.Addr().String(), gs.Equals, ith.ResolvedAddrStr)


### PR DESCRIPTION
Moved implementation of #763 from dev to versions/0.5 branch.
