### PR TITLE
Only add the geoip import if we geoip.h is found since Go 1.3 will barf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ if (NOT INCLUDE_GEOIP)
 else()
     message(STATUS "GeoIP.h found. Enabling GeoIP plugin.")
     set(TAGS "${TAGS} geoip")
+    set(PLUGIN_LOADER ${PLUGIN_LOADER} "github.com/mozilla-services/heka/plugins/geoip")
 endif()
 
 option(BENCHMARK "Enable the benchmark tests" off)

--- a/cmd/hekad/main.go
+++ b/cmd/hekad/main.go
@@ -31,7 +31,6 @@ import (
 	_ "github.com/mozilla-services/heka/plugins/dasher"
 	_ "github.com/mozilla-services/heka/plugins/elasticsearch"
 	_ "github.com/mozilla-services/heka/plugins/file"
-	_ "github.com/mozilla-services/heka/plugins/geoip"
 	_ "github.com/mozilla-services/heka/plugins/graphite"
 	_ "github.com/mozilla-services/heka/plugins/http"
 	_ "github.com/mozilla-services/heka/plugins/logstreamer"


### PR DESCRIPTION
on the import if the geoip tag isn't set.
