### PR TITLE
Default FileOutput to use message framing

### DIFF
--- a/docs/source/config/outputs/file.rst
+++ b/docs/source/config/outputs/file.rst
@@ -8,9 +8,6 @@ Config:
 
 - path (string):
     Full path to the output file.
-- prefix_ts (bool, optional):
-    Whether a timestamp should be prefixed to each message line in the file.
-    Defaults to ``false``.
 - perm (string, optional):
     File permission for writing. A string of the octal digit representation.
     Defaults to "644".
@@ -28,6 +25,9 @@ Config:
     Operator describing how the two parameters "flush_interval" and
     "flush_count" are combined. Allowed values are "AND" or "OR" (default is
     "AND").
+- use_framing (bool, optional):
+    Specifies whether or not the encoded data sent out over the TCP connection
+    should be delimited by Heka's :ref:`stream_framing`. Defaults to ``true``.
 
 Example:
 
@@ -37,8 +37,7 @@ Example:
     type = "FileOutput"
     message_matcher = "Type == 'heka.counter-output'"
     path = "/var/log/heka/counter-output.log"
-    prefix_ts = true
     perm = "666"
     flush_count = 100
     flush_operator = "OR"
-    encoder = "PayloadEncoder"
+    encoder = "ProtobufEncoder"

--- a/plugins/file/file_output.go
+++ b/plugins/file/file_output.go
@@ -31,7 +31,6 @@ import (
 // Output plugin that writes message contents to a file on the file system.
 type FileOutput struct {
 	path          string
-	prefix_ts     bool
 	perm          os.FileMode
 	flushInterval uint32
 	flushCount    uint32
@@ -68,6 +67,9 @@ type FileOutputConfig struct {
 	// directory if it doesn't exist.  Must be a string representation of an
 	// octal integer. Defaults to "700".
 	FolderPerm string `toml:"folder_perm"`
+
+	// Allows us to use framing by default.
+	UseFraming bool `toml:"use_framing"`
 }
 
 func (o *FileOutput) ConfigStruct() interface{} {
@@ -77,6 +79,7 @@ func (o *FileOutput) ConfigStruct() interface{} {
 		FlushCount:    1,
 		FlushOperator: "AND",
 		FolderPerm:    "700",
+		UseFraming:    true,
 	}
 }
 


### PR DESCRIPTION
Every FileOutput configuration in production uses the ProtobufEncoder
which requires it.
