### PR TITLE
Add note re: `. build.sh` as alternative to `source build.sh`.

### DIFF
--- a/docs/source/installing.rst
+++ b/docs/source/installing.rst
@@ -67,7 +67,7 @@ Build Instructions
     .. code-block:: bash
 
         cd heka
-        source build.sh # Unix (this file must be sourced to properly setup the environment)
+        source build.sh # Unix (or `. build.sh`; must be sourced to properly setup the environment)
         build.bat  # Windows
 
 You will now have a `hekad` binary in the `build/heka/bin` directory.


### PR DESCRIPTION
Closes #905.
