### PR TITLE
Move exports out of build.sh into env.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,16 +1,12 @@
 #!/usr/bin/env bash
 
-# if the environment has been setup before clean it up
-if [ $GOBIN ]; then
-    PATH=$(echo $PATH | sed -e "s;\(^$GOBIN:\|:$GOBIN$\|:$GOBIN\(:\)\);\2;g")
-fi
+# set up our environment
+. ./env.sh
 
-BUILD_DIR=$PWD/build
-export CTEST_OUTPUT_ON_FAILURE=1
-export GOPATH=$BUILD_DIR/heka
-export GOBIN=$GOPATH/bin
-export PATH=$PATH:$GOBIN
+NUM_JOBS=${NUM_JOBS:-1}
+
+# build heka
 mkdir -p $BUILD_DIR
 cd $BUILD_DIR
 cmake -DCMAKE_BUILD_TYPE=release ..
-make
+make -j $NUM_JOBS

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# if the environment has been setup before clean it up
+if [ $GOBIN ]; then
+    PATH=$(echo $PATH | sed -e "s;\(^$GOBIN:\|:$GOBIN$\|:$GOBIN\(:\)\);\2;g")
+fi
+
+BUILD_DIR=$PWD/build
+export CTEST_OUTPUT_ON_FAILURE=1
+export GOPATH=$BUILD_DIR/heka
+export GOBIN=$GOPATH/bin
+export PATH=$PATH:$GOBIN
+


### PR DESCRIPTION
Also set env variable in build.sh to control number of concurrent make jobs

Lets you setup the proper build environment without actually building. Useful
for if you've already built and just want to setup your GOPATH/GOBIN.
