### PR TITLE
Fix pipeline test race conditions

### DIFF
--- a/pipeline/plugin_runners.go
+++ b/pipeline/plugin_runners.go
@@ -599,11 +599,13 @@ func (foRunner *foRunner) RetainPack(pack *PipelinePack) {
 func (foRunner *foRunner) InChan() (inChan chan *PipelinePack) {
 	if foRunner.retainPack != nil {
 		retainChan := make(chan *PipelinePack)
-		go func() {
-			retainChan <- foRunner.retainPack
-			foRunner.retainPack = nil
+
+		go func(pack *PipelinePack) {
+			retainChan <- pack
 			close(retainChan)
-		}()
+		}(foRunner.retainPack)
+
+		foRunner.retainPack = nil
 		return retainChan
 	}
 	return foRunner.inChan

--- a/pipeline/stat_accum_input.go
+++ b/pipeline/stat_accum_input.go
@@ -4,7 +4,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 # The Initial Developer of the Original Code is the Mozilla Foundation.
-# Portions created by the Initial Developer are Copyright (C) 2012
+# Portions created by the Initial Developer are Copyright (C) 2012-2014
 # the Initial Developer. All Rights Reserved.
 #
 # Contributor(s):
@@ -91,7 +91,7 @@ type StatAccumInputConfig struct {
 
 	// Don't emit values for inactive stats instead of sending 0 or in the case
 	// of gauges, sending the previous value. Defaults to false
-	DeleteIdleStats	bool	`toml:"delete_idle_stats"`
+	DeleteIdleStats bool `toml:"delete_idle_stats"`
 }
 
 func (sm *StatAccumInput) ConfigStruct() interface{} {


### PR DESCRIPTION
Small foRunner code change and significant restructuring of StatAccumInput tests to remove all race conditions from the pipeline package tests.
