### PR TITLE
Issue #741 symlink log_directory

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,9 @@ Backwards Incompatibilities
 Bug Handling
 ------------
 
+* Added support for a Logstreamer symbolically linked log_directory root 
+  (issue #741).
+
 * Fixed lots of race conditions in the tests.
 
 Features

--- a/logstreamer/filehandling.go
+++ b/logstreamer/filehandling.go
@@ -396,6 +396,7 @@ func NewLogstreamSet(sortPattern *SortPattern, oldest time.Duration,
 	}
 	sortPattern.Translation = newTranslation
 
+	logRoot, _ = filepath.EvalSymlinks(logRoot)
 	return &LogstreamSet{
 		logstreams:     make(map[string]*Logstream),
 		oldestDuration: oldest,


### PR DESCRIPTION
This will only address the issue for the root directory,
filepath.Walk will not follow symlinks below it.
http://golang.org/pkg/path/filepath/#Walk
