### PR TITLE
Switch to upstream go-ircevent.

### DIFF
--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -152,7 +152,7 @@ git_clone(https://github.com/crowdmob/goamz e9a919b6da95151fc77b1b7bb3e78a8a6837
 git_clone(https://github.com/rafrombrc/gospec 2e46585948f47047b0c217d00fa24bbc4e370e6b)
 git_clone(https://github.com/crankycoder/g2s 2594f7a035ed881bb10618bc5dc4440ef35c6a29)
 git_clone(https://github.com/crankycoder/xmlpath 670b185b686fd11aa115291fb2f6dc3ed7ebb488)
-git_clone(https://github.com/ecnahc515/go-ircevent 06fee2df7d48a003b45505f9fdae099252742579)
+git_clone(https://github.com/thoj/go-ircevent 90dc7f966b95d133f1c65531c6959b52effd5e40)
 
 if (INCLUDE_GEOIP)
     add_external_plugin(git https://github.com/abh/geoip da130741c8ed2052f5f455d56e552f2e997e1ce9)

--- a/plugins/irc/irc_output.go
+++ b/plugins/irc/irc_output.go
@@ -17,9 +17,9 @@ package irc
 import (
 	"errors"
 	"fmt"
-	"github.com/ecnahc515/go-ircevent"
 	"github.com/mozilla-services/heka/pipeline"
 	"github.com/mozilla-services/heka/plugins/tcp"
+	"github.com/thoj/go-ircevent"
 	"sync"
 	"sync/atomic"
 	"time"

--- a/plugins/irc/irc_output_test.go
+++ b/plugins/irc/irc_output_test.go
@@ -16,13 +16,13 @@ package irc
 
 import (
 	"fmt"
-	"github.com/ecnahc515/go-ircevent"
 	. "github.com/mozilla-services/heka/pipeline"
 	pipeline_ts "github.com/mozilla-services/heka/pipeline/testsupport"
 	"github.com/mozilla-services/heka/plugins"
 	plugins_ts "github.com/mozilla-services/heka/plugins/testsupport"
 	"github.com/rafrombrc/gomock/gomock"
 	gs "github.com/rafrombrc/gospec/src/gospec"
+	"github.com/thoj/go-ircevent"
 	"sync"
 	"testing"
 	"time"

--- a/plugins/irc/irc_types.go
+++ b/plugins/irc/irc_types.go
@@ -18,8 +18,8 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"github.com/ecnahc515/go-ircevent"
 	"github.com/mozilla-services/heka/plugins/tcp"
+	"github.com/thoj/go-ircevent"
 	"time"
 )
 

--- a/plugins/irc/mock_connection.go
+++ b/plugins/irc/mock_connection.go
@@ -16,8 +16,7 @@ package irc
 
 import (
 	"errors"
-
-	"github.com/ecnahc515/go-ircevent"
+	"github.com/thoj/go-ircevent"
 )
 
 type MockIrcConnection struct {


### PR DESCRIPTION
I'd like to change the version of go-ircevent heka depends on to upstream, since they've picked up @ecnahc515's changes and a [TLS fix of mine](https://github.com/thoj/go-ircevent/pull/41).
