### PR TITLE
Fix the MySQL slow query grammar to handle logs with no line feed

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,6 +27,8 @@ Backwards Incompatibilities
 Bug Handling
 ------------
 
+* Fixed the MySQL slow query grammar to handle logs with no newline.
+
 * Fixed packet tracking idle packs error output formatting.
 
 * Prevent panics during shutdown when a restarting plugin has been restarted

--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -19,7 +19,7 @@ if(INCLUDE_SANDBOX)
     externalproject_add(
         ${SANDBOX_PACKAGE}
         GIT_REPOSITORY https://github.com/mozilla-services/lua_sandbox.git
-        GIT_TAG 3da8912fe29e3fdd865b7f476d79cbe300d6af74
+        GIT_TAG eab9fc6cb1ca6dc67fb56d1aa19146d4e44acae8
         CMAKE_ARGS ${SANDBOX_ARGS}
         INSTALL_DIR ${PROJECT_PATH}
     )

--- a/sandbox/plugins/sandbox_decoders_test.go
+++ b/sandbox/plugins/sandbox_decoders_test.go
@@ -675,8 +675,7 @@ SET last_insert_id=999,insert_id=1000,timestamp=1399500744;
 # administrator command: do something
 /* [queryName=FIND_ITEMS] */ SELECT *
 FROM widget
-WHERE id = 10;
-`
+WHERE id = 10;`
 			pack.Message.SetPayload(data)
 			_, err = decoder.Decode(pack)
 			c.Assume(err, gs.IsNil)
@@ -715,8 +714,7 @@ WHERE id = 10;
 SET timestamp=1399500744;
 /* [queryName=FIND_ITEMS] */ SELECT *
 FROM widget
-WHERE id = 10;
-`
+WHERE id = 10;`
 			pack.Message.SetPayload(data)
 			_, err = decoder.Decode(pack)
 			c.Assume(err, gs.IsNil)


### PR DESCRIPTION
The splitter removed the line feed that the grammar was expecting.  It only
successfully parsed logs preceeding the optional '# Time ...' output line (so
only one entry for each second of log).
