### PR TITLE
Fixed syntax error in IrcOutput example.

### DIFF
--- a/docs/source/config/outputs/irc.rst
+++ b/docs/source/config/outputs/irc.rst
@@ -71,7 +71,7 @@ Example:
     encoder = "PayloadEncoder"
     server = "irc.mozilla.org:6667"
     nick = "heka_bot"
-    ident "heka_ident"
+    ident = "heka_ident"
     channels = [ "#heka_bot_irc testkeypassword" ]
     rejoin_on_kick = true
     queue_size = 200


### PR DESCRIPTION
```
modified:   irc.rst
```
