### PR TITLE
Improve TcpInput and TcpOutput handling of keep_alive_period default

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,15 @@
-0.7.1 (2014-MM-DD)
+0.7.1 (2014-09-02)
 ==================
 
 Bug Handling
 ------------
-* Fixed load ordering of nested MultiDecoders (#1045)
 
+* Fixed handling of TcpInput and TcpOutput keep_alive_period default value
+  handling, and added docs (#1054).
+
+* Fixed OSX lua_sandbox build error.
+
+* Fixed load ordering of nested MultiDecoders (#1045).
 
 0.7.0 (2014-08-27)
 ==================

--- a/docs/source/config/inputs/tcp.rst
+++ b/docs/source/config/inputs/tcp.rst
@@ -51,6 +51,16 @@ Config:
 - net (string, optional, default: "tcp")
     Network value must be one of: "tcp", "tcp4", "tcp6", "unix" or "unixpacket".
 
+.. versionadded:: 0.6
+
+- keep_alive (bool):
+    Specifies whether or not `TCP keepalive
+    <http://en.wikipedia.org/wiki/Keepalive#TCP_keepalive>`_ should be used
+    for established TCP connections. Defaults to false.
+- keep_alive_period (int):
+    Time duration in seconds that a TCP connection will be maintained before
+    keepalive probes start being sent. Defaults to 7200 (i.e. 2 hours).
+
 Example:
 
 .. code-block:: ini

--- a/docs/source/config/outputs/tcp.rst
+++ b/docs/source/config/outputs/tcp.rst
@@ -38,6 +38,13 @@ Config:
     Specifies whether or not the encoded data sent out over the TCP connection
     should be delimited by Heka's :ref:`stream_framing`. Defaults to true if a
     ProtobufEncoder is used, false otherwise.
+- keep_alive (bool):
+    Specifies whether or not `TCP keepalive
+    <http://en.wikipedia.org/wiki/Keepalive#TCP_keepalive>`_ should be used
+    for established TCP connections. Defaults to false.
+- keep_alive_period (int):
+    Time duration in seconds that a TCP connection will be maintained before
+    keepalive probes start being sent. Defaults to 7200 (i.e. 2 hours).
 
 Example:
 


### PR DESCRIPTION
interval, and update docs to include keepalive info. Closes #1054.
