### PR TITLE
Add a carriage return after the payload

### DIFF
--- a/sandbox/lua/encoders/es_payload.lua
+++ b/sandbox/lua/encoders/es_payload.lua
@@ -66,6 +66,7 @@ local ts_from_message = read_config("es_index_from_timestamp")
 local index = read_config("index") or "heka-%{%Y.%m.%d}"
 local type_name = read_config("type_name") or "message"
 local id = read_config("id")
+local byte = string.byte
 
 function process_message()
     local ns
@@ -73,7 +74,11 @@ function process_message()
         ns = read_message("Timestamp")
     end
     local idx_json = elasticsearch.bulkapi_index_json(index, type_name, id, ns)
-    add_to_payload(idx_json, "\n", read_message("Payload"), "\n")
+    local payload = read_message("Payload")
+    add_to_payload(idx_json, "\n", payload)
+    if 10 ~= byte(payload, #payload) then
+        add_to_payload("\n")
+    end
     inject_payload()
     return 0
 end


### PR DESCRIPTION
When the payload doesn't have a newline character at the end, ElasticSearchOutput plugin returns this error:

```
Plugin 'ElasticSearchOutput' error: HTTP response error status: 500 Internal Server Error
```

Tracing down it, leads me to discover that this was the error returned by ES:

``` json
{
    "error": "ActionRequestValidationException[Validation Failed: 1: no requests added;]",
    "status": 500
}
```

That indicates an error that turned out to be that, I need one last newline character at the end of my json.

Also: `100% tests passed, 0 tests failed out of 23`

If other users, even the tests have this newline at the end, doesn't cause any trouble to always add one, and workarounds the other issue, that other users like me, could have.
