### PR TITLE
Fail early and with useful message if user omits scheme in ES server

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@
 Bug Handling
 ------------
 
+* Fail more gracefully if user doesn't specify a scheme in the server URL for
+  the ElasticSearchOutput (#1069).
+
 0.7.1 (2014-09-02)
 ==================
 

--- a/plugins/elasticsearch/elasticsearch.go
+++ b/plugins/elasticsearch/elasticsearch.go
@@ -79,13 +79,16 @@ func (o *ElasticSearchOutput) Init(config interface{}) (err error) {
 	o.batchChan = make(chan []byte)
 	o.backChan = make(chan []byte, 2)
 	o.http_timeout = conf.HTTPTimeout
-	if serverUrl, err := url.Parse(conf.Server); err == nil {
+	var serverUrl *url.URL
+	if serverUrl, err = url.Parse(conf.Server); err == nil {
 		switch strings.ToLower(serverUrl.Scheme) {
 		case "http", "https":
 			o.bulkIndexer = NewHttpBulkIndexer(strings.ToLower(serverUrl.Scheme), serverUrl.Host,
 				o.flushCount, o.http_timeout)
 		case "udp":
 			o.bulkIndexer = NewUDPBulkIndexer(serverUrl.Host, o.flushCount)
+		default:
+			err = errors.New("Server URL must specify one of `udp`, `http`, or `https`.")
 		}
 	} else {
 		err = fmt.Errorf("Unable to parse ElasticSearch server URL [%s]: %s", conf.Server, err)


### PR DESCRIPTION
URL. Closes #1069.
