### PR TITLE
Added support for encoders to swallow messages w/o generating any

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,12 @@ Features
 
 * Support environment variables in config files (#1023).
 
+* Encoders can now return (nil, nil) to express that they've swallowed the
+  input message without generating any output.
+
+* SandboxEncoder now supports return value of -2 from the process_message call
+  to specify that no output is being generated.
+
 0.7.2 (2014-MM-DD)
 ==================
 

--- a/docs/source/developing/plugin.rst
+++ b/docs/source/developing/plugin.rst
@@ -533,14 +533,18 @@ The `Encoder` interface consists of one method::
 
 This method accepts a PiplelinePack containing a populated message object and
 returns a byte slice containing the data that should be sent out, or an error
-if serialization fails for some reason.
+if serialization fails for some reason. If the encoder wishes to swallow an
+input message without generating any output (such as for batching, or because
+the message contains no new data) then nil should be returned for both the
+output and the error.
 
 Unlike the other plugin types, encoders don't have a PluginRunner, nor do they
 run in their own goroutines. Outputs invoke encoders directly, by calling the
 Encode method exposed on the OutputRunner. This has the same signature as the
-Encoder interface's Encode method, to which it will will delegate. If `use_framing` is
-set to true in the output's configuration, however, the OutputRunner will
-prepend Heka's :ref:`stream_framing` to the generated binary data.
+Encoder interface's Encode method, to which it will will delegate. If
+`use_framing` is set to true in the output's configuration, however, the
+OutputRunner will prepend Heka's :ref:`stream_framing` to the generated binary
+data.
 
 Outputs can also directly access their encoder instance by calling
 OutputRunner.Encoder(). Encoders themselves don't handle the stream framing,

--- a/docs/source/sandbox/lua.rst
+++ b/docs/source/sandbox/lua.rst
@@ -24,6 +24,7 @@ Functions that must be exposed from the Lua sandbox
 
     *Return*
         - < 0 for non-fatal failure (increments ProcessMessageFailures)
+        - -2 for no output, but no error (encoders only)
         - 0 for success
         - > 0 for fatal error (terminates the sandbox)
 

--- a/pipeline/buffered_output.go
+++ b/pipeline/buffered_output.go
@@ -71,7 +71,7 @@ func NewBufferedOutput(queue_dir, queue_name string, or OutputRunner, h PluginHe
 
 func (b *BufferedOutput) QueueRecord(pack *PipelinePack) (err error) {
 	var msgBytes []byte
-	if msgBytes, err = b.or.Encode(pack); err != nil {
+	if msgBytes, err = b.or.Encode(pack); msgBytes == nil || err != nil {
 		return
 	}
 

--- a/plugins/amqp/amqp_output.go
+++ b/plugins/amqp/amqp_output.go
@@ -159,6 +159,9 @@ func (ao *AMQPOutput) Run(or OutputRunner, h PluginHelper) (err error) {
 				or.LogError(fmt.Errorf("Error encoding message: %s", err))
 				pack.Recycle()
 				continue
+			} else if outBytes == nil {
+				pack.Recycle()
+				continue
 			}
 			amqpMsg = amqp.Publishing{
 				DeliveryMode: persist,

--- a/plugins/elasticsearch/elasticsearch.go
+++ b/plugins/elasticsearch/elasticsearch.go
@@ -135,7 +135,7 @@ func (o *ElasticSearchOutput) receiver(or OutputRunner, wg *sync.WaitGroup) {
 			pack.Recycle()
 			if e != nil {
 				or.LogError(e)
-			} else {
+			} else if outBytes != nil {
 				outBatch = append(outBatch, outBytes...)
 				if count = count + 1; o.bulkIndexer.CheckFlush(count, len(outBatch)) {
 					if len(outBatch) > 0 {

--- a/plugins/file/file_output.go
+++ b/plugins/file/file_output.go
@@ -195,7 +195,7 @@ func (o *FileOutput) receiver(or OutputRunner, wg *sync.WaitGroup) {
 			}
 			if outBytes, e = or.Encode(pack); e != nil {
 				or.LogError(e)
-			} else {
+			} else if outBytes != nil {
 				outBatch = append(outBatch, outBytes...)
 				msgCounter++
 			}

--- a/plugins/http/http_output.go
+++ b/plugins/http/http_output.go
@@ -104,6 +104,9 @@ func (o *HttpOutput) Run(or pipeline.OutputRunner, h pipeline.PluginHelper) (err
 			or.LogError(e)
 			continue
 		}
+		if outBytes == nil {
+			continue
+		}
 		if e = o.request(or, outBytes); e != nil {
 			or.LogError(e)
 		}

--- a/plugins/irc/irc_output.go
+++ b/plugins/irc/irc_output.go
@@ -169,7 +169,7 @@ func (output *IrcOutput) Run(runner pipeline.OutputRunner,
 		outgoing, err = runner.Encode(pack)
 		if err != nil {
 			output.runner.LogError(err)
-		} else {
+		} else if outgoing != nil {
 			// Send the message to each irc channel. If the out queue is full,
 			// then we need to drop the message and log an error.
 			for i, ircChannel := range output.Channels {

--- a/plugins/log_output.go
+++ b/plugins/log_output.go
@@ -45,7 +45,7 @@ func (self *LogOutput) Run(or OutputRunner, h PluginHelper) (err error) {
 	for pack = range inChan {
 		if outBytes, e = or.Encode(pack); e != nil {
 			or.LogError(fmt.Errorf("Error encoding message: %s", e))
-		} else {
+		} else if outBytes != nil {
 			log.Print(string(outBytes))
 		}
 		pack.Recycle()

--- a/plugins/smtp/smtp_output.go
+++ b/plugins/smtp/smtp_output.go
@@ -122,7 +122,7 @@ func (s *SmtpOutput) Run(or OutputRunner, h PluginHelper) (err error) {
 	for pack = range inChan {
 		message = headerText
 
-		if contents, err = s.encoder.Encode(pack); err == nil {
+		if contents, err = s.encoder.Encode(pack); contents != nil && err == nil {
 			message += "\r\n" + base64.StdEncoding.EncodeToString(contents)
 			err = s.sendFunction(s.conf.Host, s.auth, s.conf.SendFrom, s.conf.SendTo, []byte(message))
 		}

--- a/plugins/udp/udp_output.go
+++ b/plugins/udp/udp_output.go
@@ -105,7 +105,7 @@ func (o *UdpOutput) Run(or pipeline.OutputRunner, h pipeline.PluginHelper) (err 
 	for pack := range or.InChan() {
 		if outBytes, e = or.Encode(pack); e != nil {
 			or.LogError(fmt.Errorf("Error encoding message: %s", e.Error()))
-		} else {
+		} else if outBytes != nil {
 			o.conn.Write(outBytes)
 		}
 		pack.Recycle()

--- a/sandbox/plugins/sandbox_encoder.go
+++ b/sandbox/plugins/sandbox_encoder.go
@@ -194,6 +194,10 @@ func (s *SandboxEncoder) Encode(pack *pipeline.PipelinePack) (output []byte, err
 		err = fmt.Errorf("FATAL: %s", s.sb.LastError())
 		return
 	}
+	if retval == -2 {
+		// Encoder has nothing to return.
+		return nil, nil
+	}
 	if retval < 0 {
 		atomic.AddInt64(&s.processMessageFailures, 1)
 		err = errors.New("Failed serializing.")


### PR DESCRIPTION
output, and added support for sandbox encoders to return -2 from
process_message to do the same.
