### PR TITLE
Graylog2 Extended Format Decoder

### DIFF
--- a/docs/source/config/decoders/index.rst
+++ b/docs/source/config/decoders/index.rst
@@ -14,6 +14,16 @@ Apache Access Log Decoder
    :start-after: --[[
    :end-before: --]]
 
+.. _config_graylog_extended_log_format_decoder:
+
+Graylog Extended Log Format Decoder
+===================================
+
+.. versionadded:: 0.8
+.. include:: /../../sandbox/lua/decoders/graylog_extended.lua
+   :start-after: --[[
+   :end-before: --]]
+
 .. versionadded:: 0.6
 .. _config_geoip_decoder:
 .. include:: /config/decoders/geoip_decoder.rst

--- a/docs/source/config/decoders/index_noref.rst
+++ b/docs/source/config/decoders/index_noref.rst
@@ -11,6 +11,14 @@ Apache Access Log Decoder
    :start-after: --[[
    :end-before: --]]
 
+Graylog Extended Log Format Decoder
+===================================
+
+.. versionadded:: 0.8
+.. include:: /../../sandbox/lua/decoders/graylog_extended.lua
+   :start-after: --[[
+   :end-before: --]]
+
 .. versionadded:: 0.6
 .. include:: /config/decoders/geoip_decoder.rst
 

--- a/docs/source/sandbox/decoder.rst
+++ b/docs/source/sandbox/decoder.rst
@@ -13,6 +13,12 @@ Apache Access Log Decoder
    :start-after: --[[
    :end-before: --]]
 
+Graylog Extended Log Format Decoder
+-----------------------------------
+.. include:: ../../../sandbox/lua/decoders/graylog_extended.lua
+   :start-after: --[[
+   :end-before: --]]
+
 MySQL Slow Query Log Decoder
 ----------------------------
 .. include:: ../../../sandbox/lua/decoders/mysql_slow_query.lua

--- a/sandbox/lua/decoders/graylog_extended.lua
+++ b/sandbox/lua/decoders/graylog_extended.lua
@@ -1,0 +1,94 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+--[[
+Parses a payload containing JSON in the Graylog2 Extended Format specficiation.
+http://graylog2.org/resources/gelf/specification
+
+Config:
+
+- type (string, optional, default nil):
+    Sets the message 'Type' header to the specified value
+
+- payload_keep (bool, optional, default false)
+    Always preserve the original log line in the message payload.
+
+*Example of Graylog2 Exteded Format Log*
+
+.. code-block:: javascript
+
+  {
+    "version": "1.1",
+    "host": "rogueethic.com",
+    "short_message": "This is a short message to identify what is going on.",
+    "full_message": "An entire backtrace\ncould\ngo\nhere",
+    "timestamp": 1385053862.3072,
+    "level": 1,
+    "_user_id": 9001,
+    "_some_info": "foo",
+    "_some_env_var": "bar"
+  }
+
+*Example Heka Configuration*
+
+.. code-block:: ini
+
+    [GELFLogInput]
+    type = "LogstreamerInput"
+    log_directory = "/var/log"
+    file_match = 'application\.gelf'
+    decoder = "GraylogDecoder"
+
+    [GraylogDecoder]
+    type = "SandboxDecoder"
+    filename = "lua_decoders/graylog_decoder.lua"
+
+        [GraylogDecoder.config]
+        type = "gelf"
+        payload_keep = true
+--]]
+
+require "cjson"
+
+local msg_type     = read_config("type")
+local payload_keep = read_config("payload_keep")
+
+local msg = {
+    Timestamp  = nil,
+    EnvVersion = nil,
+    Host       = nil,
+    Type       = msg_type,
+    Payload    = nil,
+    Fields     = nil,
+    Severity   = nil
+}
+
+function process_message()
+    local ok, json = pcall(cjson.decode, read_message("Payload"))
+    if not ok then
+        return -1
+    end
+
+    if payload_keep then
+        msg.Payload = read_message("Payload")
+    end
+
+    if type(json["timestamp"]) ~= "number" then return -1 end
+    msg.Timestamp = json["timestamp"] * 1e9
+
+    msg.EnvVersion = json["version"]
+    msg.Severity = json["level"]
+    msg.Host = json["host"]
+    msg.Fields = json
+
+    -- Remove original fields to avoid duplication
+    json["timestamp"] = nil
+    json["version"] = nil
+    json["level"] = nil
+    json["host"] = nil
+ 
+    if not pcall(inject_message, msg) then return -1 end
+ 
+    return 0
+end


### PR DESCRIPTION
A simple decoder for the Graylog2 Extended Format for logging based on some code I saw in a blog @trink had assisted with. This should work with the specification for GELF. The logical next step would be a Graylog Output for the server but it is sufficient for my uses to simply ingest GELF so it can be tossed at ES+Kibana.
