### PR TITLE
Add heka-docker as external plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ set(HEKA_CAT_EXE "${PROJECT_PATH}/bin/heka-cat${CMAKE_EXECUTABLE_SUFFIX}")
 
 option(INCLUDE_SANDBOX "Include Lua sandbox" on)
 option(INCLUDE_MOZSVC "Include the Mozilla services plugins" on)
+option(INCLUDE_DOCKER_INPUT "Inlcude Docker input plugin" on)
 
 find_path(INCLUDE_GEOIP GeoIP.h /usr/local/include /usr/include /opt/local/include)
 if (NOT INCLUDE_GEOIP)

--- a/build.bat
+++ b/build.bat
@@ -9,5 +9,5 @@ endlocal & set GOPATH=%NEWGOPATH%& set GOBIN=%NEWGOPATH%\bin& set PATH=%p%;%NEWG
 
 if NOT exist %BUILD_DIR% mkdir %BUILD_DIR%
 cd %BUILD_DIR%
-cmake -DINCLUDE_MOZSVC=false -DCMAKE_BUILD_TYPE=release -G"MinGW Makefiles" ..
+cmake -DINCLUDE_MOZSVC=false -DINCLUDE_DOCKER_INPUT=false -DCMAKE_BUILD_TYPE=release -G"MinGW Makefiles" ..
 mingw32-make

--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -164,6 +164,12 @@ if (INCLUDE_MOZSVC)
     add_dependencies(heka-mozsvc-plugins raven-go)
 endif()
 
+if (INCLUDE_DOCKER_INPUT)
+    add_external_plugin(git https://github.com/carlanton/heka-docker 6f09ff193c2b326e6368c80911cb5c05afac12ba)
+    git_clone(https://github.com/fsouza/go-dockerclient 0236a64c6c4bd563ec277ba00e370cc753e1677c)
+    add_dependencies(heka-docker go-dockerclient)
+endif()
+
 if (INCLUDE_DOCUMENTATION)
     git_clone(https://github.com/mozilla-services/heka-docs cb4a1610579c02bb25a8c0aaf835b05c3214d532)
 


### PR DESCRIPTION
See: #1092 

This PR includes carlanton/heka-docker (Docker input support) in heka core.

@rafrombrc Was it something like this you had in mind? I suppose that it would be better if heka-docker was transfered to mozilla-services.
