### PR TITLE
Fix a couple of very small doc typos

### DIFF
--- a/docs/source/config/index.rst
+++ b/docs/source/config/index.rst
@@ -283,8 +283,8 @@ Example:
     message_matcher = 'Logger == "TestWebserver"'
 
     [AMQPOutput.retries]
-    max_delay = 30s
-    delay = 250ms
+    max_delay = "30s"
+    delay = "250ms"
     max_retries = 5
 
 .. end-restarting

--- a/docs/source/config/inputs/process.rst
+++ b/docs/source/config/inputs/process.rst
@@ -61,7 +61,7 @@ cmd_config structure:
     The full path to the binary that will be executed.
 - args ([]string):
     Command line arguments to pass into the executable.
-- environment ([]string):
+- env ([]string):
     Used to set environment variables before `command` is run. Default is nil,
     which uses the heka process's environment.
 - directory (string):


### PR DESCRIPTION
The strings in the 'retries' config need quoting, and the ProcessInput 'environment' config is actually 'env'.
