### PR TITLE
Add ability to drop big message entirely or to decode first part of it

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -81,6 +81,8 @@ Features
   timestamp formats to the time parsing code used by the Payload*Decoder
   plugins (#963).
 
+* Added ability to drop big message entirely or to keep first part of it (#1134)
+
 0.7.3 (2014-10-28)
 ==================
 

--- a/docs/source/config/inputs/logstreamer.rst
+++ b/docs/source/config/inputs/logstreamer.rst
@@ -72,4 +72,6 @@ Config:
 - delimiter_location (string): Only used for regexp parsers.
     - start - the regexp delimiter occurs at the start of a log line.
     - end - the regexp delimiter occurs at the end of the log line (default).
+- keep_truncated_messages (bool): Only used for token or regexp parsers.
+    Whether to keep first part of big message exceeding buffer size or just drop it (default).
 

--- a/pipeline/stream_parser.go
+++ b/pipeline/stream_parser.go
@@ -122,6 +122,10 @@ func NewTokenParser() (t *TokenParser) {
 func (t *TokenParser) Parse(reader io.Reader) (bytesRead int, record []byte, err error) {
 	if t.needData {
 		if bytesRead, err = t.read(reader); err != nil {
+			if err == io.ErrShortBuffer {
+				record = t.buf
+				// return truncated message and allow input plugin to decide what to do with it
+			}
 			return
 		}
 	}
@@ -203,6 +207,10 @@ func (r *RegexpParser) SetDelimiterLocation(location string) (err error) {
 func (r *RegexpParser) Parse(reader io.Reader) (bytesRead int, record []byte, err error) {
 	if r.needData {
 		if bytesRead, err = r.read(reader); err != nil {
+			if err == io.ErrShortBuffer {
+				record = r.buf
+				// return truncated message and allow input plugin to decide what to do with it
+			}
 			return
 		}
 	}

--- a/pipeline/stream_parser_test.go
+++ b/pipeline/stream_parser_test.go
@@ -238,7 +238,7 @@ func StreamParserSpec(c gs.Context) {
 			n, record, err = p.Parse(reader)
 		}
 		c.Expect(n, gs.Equals, message.MAX_RECORD_SIZE)
-		c.Expect(len(record), gs.Equals, 0)
+		c.Expect(len(record), gs.Equals, message.MAX_RECORD_SIZE)
 		c.Expect(err, gs.Equals, io.ErrShortBuffer)
 	})
 }


### PR DESCRIPTION
1) return big message from text parsers (token and regexp, but not from the  binary protobuf parser). 
2) Logstreamer: 
- drop this message entirely (first exceeding part and all next whether they also big or not) or
  -  decode only cutted first part of it (depends on new config option) and ignore next parts.
