### PR TITLE
Optional HTTP authentication against the ElasticSearch HTTP server

### DIFF
--- a/docs/source/config/outputs/elasticsearch.rst
+++ b/docs/source/config/outputs/elasticsearch.rst
@@ -30,6 +30,12 @@ Config:
     ElasticSearch should be disabled. Defaults to false, that means using
     both HTTP keep-alive mode and TCP keep-alives. Set it to true to close
     each TCP connection after 'flushing' messages to ElasticSearch.
+- username (string):
+    The username to use for HTTP authentication against the ElasticSearch host.
+    Defaults to "" (i. e. no authentication).
+- password (string):
+    The password to use for HTTP authentication against the ElasticSearch host.
+    Defaults to "" (i. e. no authentication).
 
 Example:
 


### PR DESCRIPTION
This is needed if you have put a proxy before your ElasticSearch
server that uses HTTPS and Basic Auth to protect access to the
ElasticSearch server.

Due to a "go fmt" run this diff is a little longer than absolutely necessary.
