### PR TITLE
select order doesn't matter

### DIFF
--- a/plugins/kafka/kafka_output.go
+++ b/plugins/kafka/kafka_output.go
@@ -284,7 +284,6 @@ func (k *KafkaOutput) Run(or pipeline.OutputRunner, h pipeline.PluginHelper) (er
 	}
 
 	inChan := or.InChan()
-	errChan := k.producer.Errors()
 
 	var (
 		pack  *pipeline.PipelinePack


### PR DESCRIPTION
@rafrombrc learned me that select order doesn't matter. since we need a separate select for errChan, makes sense to just range over the inChan?
