### PR TITLE
Fix leaky file descriptor bug on http_output.go

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@
 Bug Handling
 ------------
 
+* Fix leaky file descriptor bug on http_output.go.
+
 0.8.0 (2014-10-29)
 ==================
 

--- a/plugins/http/http_output.go
+++ b/plugins/http/http_output.go
@@ -140,6 +140,8 @@ func (o *HttpOutput) request(or pipeline.OutputRunner, outBytes []byte) (err err
 	if resp, err = o.client.Do(req); err != nil {
 		return fmt.Errorf("Error making HTTP request: %s", err.Error())
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode >= 400 {
 		var body []byte
 		if resp.ContentLength > 0 {


### PR DESCRIPTION
This is a PR for versions/0.8 branch to fix leaky file descriptor bug, replacing this PR: https://github.com/mozilla-services/heka/pull/1159
