### PR TITLE
Always recycle, and CleanupForRestart doesn't need to duplicate what

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,9 +7,13 @@ Bug Handling
 * Fix leaky file descriptor bug on http_output.go.
 
 * Only stamp PipelinePack diagnostics in cases when a pack actually matches a
-  message matcher, instead of for every matcher every time.
+  message matcher, instead of for every matcher every time (#1167).
 
-* StatsdInput allows to specify (via max_msg_size option) size of message read from UDP.
+* StatsdInput allows to specify (via max_msg_size option) size of message read
+  from UDP (#1165).
+
+* AMQPOutput now recycles packs even when a publish error causes the output to
+  exit / restart (#1178).
 
 0.8.0 (2014-10-29)
 ==================

--- a/plugins/amqp/amqp_output.go
+++ b/plugins/amqp/amqp_output.go
@@ -171,6 +171,7 @@ func (ao *AMQPOutput) Run(or OutputRunner, h PluginHelper) (err error) {
 				pack.Recycle()
 				continue
 			}
+			pack.Recycle()
 			amqpMsg = amqp.Publishing{
 				DeliveryMode: persist,
 				Timestamp:    time.Now(),
@@ -181,8 +182,6 @@ func (ao *AMQPOutput) Run(or OutputRunner, h PluginHelper) (err error) {
 				false, false, amqpMsg)
 			if err != nil {
 				ok = false
-			} else {
-				pack.Recycle()
 			}
 		}
 	}
@@ -194,8 +193,6 @@ func (ao *AMQPOutput) Run(or OutputRunner, h PluginHelper) (err error) {
 }
 
 func (ao *AMQPOutput) CleanupForRestart() {
-	ao.amqpHub.Close(ao.config.URL, ao.connWg)
-	ao.connWg.Wait()
 	return
 }
 


### PR DESCRIPTION
already happens when Run exits. Closes #1178.
