### PR TITLE
Improve error reporting from ElasticSearch output

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,7 +11,10 @@ Features
 --------
 
 * Select unit type and aggregation methods for stats graph
+
 * Added option (immediate_start) to start process immediately in ProcessInput.
+
+* Slightly improve error output in ElasticSearch plugin.
  
 0.8.1 (2014-MM-DD)
 ==================

--- a/plugins/elasticsearch/elasticsearch.go
+++ b/plugins/elasticsearch/elasticsearch.go
@@ -17,6 +17,7 @@ package elasticsearch
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	. "github.com/mozilla-services/heka/pipeline"
@@ -233,25 +234,42 @@ func (h *HttpBulkIndexer) CheckFlush(count int, length int) bool {
 }
 
 func (h *HttpBulkIndexer) Index(body []byte) error {
+	var response_body []byte
+	var response_body_json map[string]interface{}
+
 	url := fmt.Sprintf("%s://%s%s", h.Protocol, h.Domain, "/_bulk")
 
 	// Creating ElasticSearch Bulk HTTP request
 	request, err := http.NewRequest("POST", url, bytes.NewReader(body))
 	if err != nil {
-		return fmt.Errorf("can't create bulk request: %s", err.Error())
+		return fmt.Errorf("Can't create bulk request: %s", err.Error())
 	}
 	request.Header.Add("Accept", "application/json")
+	request_start_time := time.Now()
 	response, err := h.client.Do(request)
+	request_time := time.Since(request_start_time)
 	if err != nil {
-		return fmt.Errorf("HTTP request failed: %s", err.Error())
+		if (h.client.Timeout > 0) && (request_time >= h.client.Timeout) && (strings.Contains(err.Error(), "use of closed network connection")) {
+			return fmt.Errorf("HTTP request was interrupted after timeout. It lasted %s", request_time.String())
+		} else {
+			return fmt.Errorf("HTTP request failed: %s", err.Error())
+		}
 	}
 	if response != nil {
 		defer response.Body.Close()
 		if response.StatusCode > 304 {
 			return fmt.Errorf("HTTP response error status: %s", response.Status)
 		}
-		if _, err = ioutil.ReadAll(response.Body); err != nil {
-			return fmt.Errorf("can't read HTTP response body: %s", err.Error())
+		if response_body, err = ioutil.ReadAll(response.Body); err != nil {
+			return fmt.Errorf("Can't read HTTP response body: %s", err.Error())
+		}
+		err = json.Unmarshal(response_body, &response_body_json)
+		if err != nil {
+			return fmt.Errorf("HTTP response didn't contain valid JSON. Body: %s", string(response_body))
+		}
+		json_errors, ok := response_body_json["errors"].(bool)
+		if ok && json_errors {
+			return fmt.Errorf("ElasticSearch server reported error within JSON: %s", string(response_body))
 		}
 	}
 	return nil


### PR DESCRIPTION
Hello!

My patch solves two tasks:
1. It returns timeout error when it was exactly timeout error.
2. It returns error which ES server reports within JSON.
I figured out, that ES server doesn't report errors as HTTP status code. For example, this is network response from my ES server:

```
HTTP/1.1 200 OK.
Content-Type: application/json; charset=UTF-8.
Content-Length: 333.
.
{"took":60000,"errors":true,"items":[{"create":{"_index":"logstash-2014.10.02","_type":"log.nginx_access","_id":"gFsWQ9ZkSQykVZelQSkrWg","status":503,"error":"UnavailableShardsException[[logstash-2014.10.02][3] [2] shardIt, [0] active : Timeout waiting for [1m], request: org.elasticsearch.action.bulk.BulkShardRequest@789439dc]"}}]}
```

As you can see, we have 200 as HTTP status code, but "errors" field indicates about error.
