### PR TITLE
ElasticSearch: add connect timeout

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,6 +19,8 @@ Features
 
 * Added `hostname` setting to global `[hekad]` config options to allow
   overriding the hostname value provided by Go's `os.Hostname` call (#1123).
+
+* Added 'connect_timeout' option in ElasticSearch output plugin.
  
 0.8.1 (2014-MM-DD)
 ==================

--- a/docs/source/config/outputs/elasticsearch.rst
+++ b/docs/source/config/outputs/elasticsearch.rst
@@ -22,6 +22,10 @@ Config:
 - server (string):
     ElasticSearch server URL. Supports http://, https:// and udp:// urls.
     Defaults to "http://localhost:9200".
+- connect_timeout (int):
+    Time in milliseconds to wait for a server name resolving and connection to ES.
+    It's included in an overall time (see 'http_timeout' option), if they both are set.
+    Default is 0 (no timeout).
 - http_timeout (int):
     Time in milliseconds to wait for a response for each http post to ES. This
     may drop data as there is currently no retry. Default is 0 (no timeout).

--- a/plugins/elasticsearch/elasticsearch.go
+++ b/plugins/elasticsearch/elasticsearch.go
@@ -39,10 +39,15 @@ type ElasticSearchOutput struct {
 	// The BulkIndexer used to index documents
 	bulkIndexer BulkIndexer
 
-	// Specify a timeout value in milliseconds for bulk request to complete.
+	// Specify an overall timeout value in milliseconds for bulk request to complete.
 	// Default is 0 (infinite)
 	http_timeout uint32
+	//Disable both TCP and HTTP keepalives
 	http_disable_keepalives bool
+	// Specify a resolve and connect timeout value in milliseconds for bulk request.
+	// It's always included in overall request timeout (see 'http_timeout' option).
+	// Default is 0 (infinite)
+	connect_timeout uint32
 }
 
 // ConfigStruct for ElasticSearchOutput plugin.
@@ -60,18 +65,22 @@ type ElasticSearchOutputConfig struct {
 	// on the local network and the indexing will be done with the UDP Bulk
 	// API. (default to "http://localhost:9200")
 	Server string
-	// Timeout
+	// Overall timeout
 	HTTPTimeout uint32 `toml:"http_timeout"`
+	// Disable both TCP and HTTP keepalives
 	HTTPDisableKeepalives bool `toml:"http_disable_keepalives"`
+	// Resolve and connect timeout only
+	ConnectTimeout uint32 `toml:"connect_timeout"`
 }
 
 func (o *ElasticSearchOutput) ConfigStruct() interface{} {
 	return &ElasticSearchOutputConfig{
-		FlushInterval: 1000,
-		FlushCount:    10,
-		Server:        "http://localhost:9200",
-		HTTPTimeout:   0,
+		FlushInterval:         1000,
+		FlushCount:            10,
+		Server:                "http://localhost:9200",
+		HTTPTimeout:           0,
 		HTTPDisableKeepalives: false,
+		ConnectTimeout:        0,
 	}
 }
 
@@ -83,12 +92,13 @@ func (o *ElasticSearchOutput) Init(config interface{}) (err error) {
 	o.backChan = make(chan []byte, 2)
 	o.http_timeout = conf.HTTPTimeout
 	o.http_disable_keepalives = conf.HTTPDisableKeepalives
+	o.connect_timeout = conf.ConnectTimeout
 	var serverUrl *url.URL
 	if serverUrl, err = url.Parse(conf.Server); err == nil {
 		switch strings.ToLower(serverUrl.Scheme) {
 		case "http", "https":
 			o.bulkIndexer = NewHttpBulkIndexer(strings.ToLower(serverUrl.Scheme), serverUrl.Host,
-				o.flushCount, o.http_timeout, o.http_disable_keepalives)
+				o.flushCount, o.http_timeout, o.http_disable_keepalives, o.connect_timeout)
 		case "udp":
 			o.bulkIndexer = NewUDPBulkIndexer(serverUrl.Host, o.flushCount)
 		default:
@@ -207,15 +217,18 @@ type HttpBulkIndexer struct {
 }
 
 func NewHttpBulkIndexer(protocol string, domain string, maxCount int,
-	httpTimeout uint32, httpDisableKeepalives bool) *HttpBulkIndexer {
+	httpTimeout uint32, httpDisableKeepalives bool, connectTimeout uint32) *HttpBulkIndexer {
 
-	tr := &http.Transport {
+	tr := &http.Transport{
 		DisableKeepAlives: httpDisableKeepalives,
+		Dial: func(network, address string) (net.Conn, error) {
+			return net.DialTimeout(network, address, time.Duration(connectTimeout)*time.Millisecond)
+		},
 	}
 
 	client := &http.Client{
 		Transport: tr,
-		Timeout: time.Duration(httpTimeout) * time.Millisecond,
+		Timeout:   time.Duration(httpTimeout) * time.Millisecond,
 	}
 	return &HttpBulkIndexer{
 		Protocol: protocol,


### PR DESCRIPTION
Are you interested in this patch?
It just add connection (and resolve) timeout to divide different situations:
- you have network error or
- you just have slow ES server
