### PR TITLE
Don't escape the request body in HTTP listen input #1124

### DIFF
--- a/docs/source/config/inputs/httplisten.rst
+++ b/docs/source/config/inputs/httplisten.rst
@@ -36,6 +36,11 @@ Config:
     by adding a TOML subsection entitled "headers" to you HttpOutput config
     section. All entries in the subsection must be a list of string values.
 
+.. versionadded:: 0.9
+
+- unescape_body (bool):
+    Whether to unescape the request body or not.
+    Defaults to true for backward compatibility reason.
 
 Example:
 

--- a/plugins/http/http_listen_input_test.go
+++ b/plugins/http/http_listen_input_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 )
 
 func HttpListenInputSpec(c gs.Context) {
@@ -110,6 +111,43 @@ func HttpListenInputSpec(c gs.Context) {
 			eq = reflect.DeepEqual(resp.Header["Four"], config.Headers["Four"])
 			c.Expect(eq, gs.IsTrue)
 
+		})
+
+		c.Specify("Unescape the request body", func() {
+			err := httpListenInput.Init(config)
+			ts.Config = httpListenInput.server
+			c.Assume(err, gs.IsNil)
+
+			startInput()
+			ith.PackSupply <- ith.Pack
+			<-startedChan
+			resp, err := http.Post(ts.URL, "text/plain", strings.NewReader("1+2"))
+			c.Assume(err, gs.IsNil)
+			resp.Body.Close()
+			c.Assume(resp.StatusCode, gs.Equals, 200)
+
+			pack := <-dRunnerInChan
+			payload := pack.Message.GetPayload()
+			c.Expect(payload, gs.Equals, "1 2")
+		})
+
+		c.Specify("Do not unescape the request body", func() {
+			config.UnescapeBody = false
+			err := httpListenInput.Init(config)
+			ts.Config = httpListenInput.server
+			c.Assume(err, gs.IsNil)
+
+			startInput()
+			ith.PackSupply <- ith.Pack
+			<-startedChan
+			resp, err := http.Post(ts.URL, "text/plain", strings.NewReader("1+2"))
+			c.Assume(err, gs.IsNil)
+			resp.Body.Close()
+			c.Assume(resp.StatusCode, gs.Equals, 200)
+
+			pack := <-dRunnerInChan
+			payload := pack.Message.GetPayload()
+			c.Expect(payload, gs.Equals, "1+2")
 		})
 
 		ts.Close()


### PR DESCRIPTION
Hi,
This is a simple change that just copies the request's body as-is into the payload instead of "unescaping" it. As I mentioned in the issue, I see no reason for calling url.QueryUnescape() in the first place but I might be wrong ;)
