### PR TITLE
Support for larger messages in statmetric_influx lua encoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pipeline/mock_*.go
 var/
 *.sw?
 externals
+.idea


### PR DESCRIPTION
Added support for processing larger messages by the `statmetric_influx` lua `SandBox` encoder. As stated in #1196, when processing a lot of accumulated data from a `StatAccumInput`, the list of stats to be serialized gets too large for cjson.

By serializing stat per stat, and performing some string concatenation, the messages can still be processed (however, increasing the `output_limit` is still required.
