### PR TITLE
Don't use pointer for TLS section in config or TOML lib will barf trying

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,8 @@ Bug Handling
 * AMQPOutput now recycles packs even when a publish error causes the output to
   exit / restart (#1178).
 
+* Fixed HttpOutput TLS section parsing (#1163).
+
 0.8.0 (2014-10-29)
 ==================
 

--- a/plugins/http/http_output.go
+++ b/plugins/http/http_output.go
@@ -43,7 +43,7 @@ type HttpOutputConfig struct {
 	Headers     http.Header
 	Username    string `toml:"username"`
 	Password    string `toml:"password"`
-	Tls         *tcp.TlsConfig
+	Tls         tcp.TlsConfig
 }
 
 func (o *HttpOutput) ConfigStruct() interface{} {
@@ -76,9 +76,9 @@ func (o *HttpOutput) Init(config interface{}) (err error) {
 	if o.Username != "" || o.Password != "" {
 		o.useBasicAuth = true
 	}
-	if o.url.Scheme == "https" && o.Tls != nil {
+	if o.url.Scheme == "https" {
 		transport := &http.Transport{}
-		if transport.TLSClientConfig, err = tcp.CreateGoTlsConfig(o.Tls); err != nil {
+		if transport.TLSClientConfig, err = tcp.CreateGoTlsConfig(&o.Tls); err != nil {
 			return fmt.Errorf("TLS init error: %s", err.Error())
 		}
 		o.client.Transport = transport


### PR DESCRIPTION
to parse it. Closes #1163.
