### PR TITLE
Allow Logger and Hostname to be overridden.

### DIFF
--- a/docs/source/sandbox/lua.rst
+++ b/docs/source/sandbox/lua.rst
@@ -174,7 +174,7 @@ Heka specific functions that are exposed to the Lua sandbox
 
     * Timestamp is automatically generated if one is not provided.  Nanosecond since the UNIX epoch is the only valid format.
     * UUID is automatically generated, anything provided by the user is ignored.
-    * Hostname and Logger are automatically set by the SandboxFilter and cannot be overridden.
+    * Hostname and Logger are automatically set by the SandboxFilter if not provided.
     * Type is prepended with "heka.sandbox." by the SandboxFilter to avoid data confusion/mis-representation.
     * Fields can be represented in multiple forms and support the following primitive types: string, double, bool.  These constructs should be added to the 'Fields' table in the message structure. Note: since the Fields structure is a map and not an array, like the protobuf message, fields cannot be repeated.
         * name=value i.e., foo="bar"; foo=1; foo=true
@@ -198,8 +198,8 @@ Sample Lua Message Structure
 
     {
     Uuid        = "data",               -- always ignored
-    Logger      = "nginx",              -- ignored in the SandboxFilter
-    Hostname    = "bogus.mozilla.com",  -- ignored in the SandboxFilter
+    Logger      = "nginx",
+    Hostname    = "bogus.mozilla.com",
 
     Timestamp   = 1e9,
     Type        = "TEST",               -- will become "heka.sandbox.TEST" in the SandboxFilter

--- a/sandbox/plugins/sandbox_filter.go
+++ b/sandbox/plugins/sandbox_filter.go
@@ -202,8 +202,16 @@ func (this *SandboxFilter) Run(fr pipeline.FilterRunner, h pipeline.PluginHelper
 			if err == nil {
 				// do not allow filters to override the following
 				pack.Message.SetType("heka.sandbox." + pack.Message.GetType())
-				pack.Message.SetLogger(fr.Name())
-				pack.Message.SetHostname(hostname)
+				if pack.Message.GetLogger() != "" {
+					pack.Message.SetLogger(pack.Message.GetLogger())
+				} else {
+					pack.Message.SetLogger(fr.Name())
+				}
+				if pack.Message.GetHostname() != "" {
+					pack.Message.SetHostname(pack.Message.GetHostname())
+				} else {
+					pack.Message.SetHostname(hostname)
+				}
 			} else {
 				return 1
 			}


### PR DESCRIPTION
I'm not sure of the original reason why they couldn't be overridden, but it would be useful to have the ability to set Logger and Hostname from inside a Filter.
If they're not set, it'll default to the original 'SandboxFilter' Logger and Hostname from a fresh Message Pack. 
