### PR TITLE
Fix log typo in HttpListenInput

### DIFF
--- a/plugins/http/http_listen_input.go
+++ b/plugins/http/http_listen_input.go
@@ -77,7 +77,7 @@ func defaultStarter(hli *HttpListenInput) (err error) {
 func (hli *HttpListenInput) RequestHandler(w http.ResponseWriter, req *http.Request) {
 	body, err := ioutil.ReadAll(req.Body)
 	if err != nil {
-		fmt.Errorf("[HttpListenInput] Read HTTP request body fail: %s\n", err.Error())
+		hli.ir.LogError(fmt.Errorf("[HttpListenInput] Read HTTP request body fail: %s\n", err.Error()))
 	}
 	req.Body.Close()
 


### PR DESCRIPTION
Found a typo in HttpListenInput.
Maybe it would be even better to return from the function when it can't read the request body?