### PR TITLE
Replaced DoesOwnDecoding interface with Deliverer objects available from...

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,13 +13,11 @@ Backwards Incompatibilities
   `send_decode_failures` config options, automatically extracted by Heka's
   config system.
 
-* InputRunner interface has added a `Deliver` method, which handles decoding
-  and injection to the router according to the specifications of the
-  `decoder`, `synchronous_decode`, and send_decode_failure` config options,
-  *except* in cases when an input implements a `SetCommonInputConfig` method.
-  If that is implemented, the InputRunner will pass in a struct containing the
-  specified decoding options, and the input will be expected to handle
-  decoding accordingly.
+* InputRunner now handles message decoding and delivery to the router,
+  according to the specifications of the input's configuration. This is
+  accomplished either directly via the `Deliver` method or, in cases where
+  decoding might need to happen in separate goroutines, through `Deliverer`
+  objects available from the `NewDeliverer` method.
 
 Bug Handling
 ------------

--- a/pipeline/flag_interfaces.go
+++ b/pipeline/flag_interfaces.go
@@ -57,13 +57,3 @@ func (s *notStoppable) IsStoppable() bool {
 func (s *notStoppable) Unregister(pConfig *PipelineConfig) error {
 	return nil
 }
-
-// DoesOwnDecoding can be implemented by an input plugin to indicate that it
-// handles creating and managing its own decoders rather than having that be
-// handled by the InputRunner. The InputRunner will call SetCommonInputConfig
-// to pass in the CommonInputConfig (which contains details re: which decoder
-// to use and how decoding should be handled) before the input's Run method is
-// called.
-type DoesOwnDecoding interface {
-	SetCommonInputConfig(commonInputConfig CommonInputConfig)
-}

--- a/pipeline/net_utils.go
+++ b/pipeline/net_utils.go
@@ -37,14 +37,14 @@ type NetworkParseFunction func(conn net.Conn,
 	parser StreamParser,
 	ir InputRunner,
 	signers map[string]Signer,
-	deliver func(*PipelinePack)) (err error)
+	deliver DeliverFunc) (err error)
 
 // Standard text log file parser
 func NetworkPayloadParser(conn net.Conn,
 	parser StreamParser,
 	ir InputRunner,
 	signers map[string]Signer,
-	deliver func(*PipelinePack)) (err error) {
+	deliver DeliverFunc) (err error) {
 	var (
 		pack   *PipelinePack
 		record []byte
@@ -81,7 +81,7 @@ func NetworkMessageProtoParser(conn net.Conn,
 	parser StreamParser,
 	ir InputRunner,
 	signers map[string]Signer,
-	deliver func(*PipelinePack)) (err error) {
+	deliver DeliverFunc) (err error) {
 	var (
 		pack   *PipelinePack
 		record []byte


### PR DESCRIPTION
... an InputRunner to ease use of parallel decoders across multiple goroutines, converted TcpInput and LogstreamInput to use Deliverers.