### PR TITLE
Handle multi-line statsd input more like statsd

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -80,7 +80,6 @@ Features
   (more like statsd itself).
   
 
->>>>>>> upstream/dev
 0.8.3 (2015-01-08)
 ==================
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -61,6 +61,11 @@ Features
 
 * Added `send_interval` setting to SmtpOutput.
 
+* Added ability for Statsd input handler to treat a malformed stat line 
+  one at time without skipping all the "good" stats in a multi-line input
+  (more like statsd itself).
+  
+
 0.8.1 (2014-12-17)
 ==================
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,13 +13,11 @@ Backwards Incompatibilities
   `send_decode_failures` config options, automatically extracted by Heka's
   config system.
 
-* InputRunner interface has added a `Deliver` method, which handles decoding
-  and injection to the router according to the specifications of the
-  `decoder`, `synchronous_decode`, and send_decode_failure` config options,
-  *except* in cases when an input implements a `SetCommonInputConfig` method.
-  If that is implemented, the InputRunner will pass in a struct containing the
-  specified decoding options, and the input will be expected to handle
-  decoding accordingly.
+* InputRunner now handles message decoding and delivery to the router,
+  according to the specifications of the input's configuration. This is
+  accomplished either directly via the `Deliver` method or, in cases where
+  decoding might need to happen in separate goroutines, through `Deliverer`
+  objects available from the `NewDeliverer` method.
 
 Bug Handling
 ------------
@@ -28,6 +26,9 @@ Bug Handling
 
 * Prevent the protobuf stream encoder from creating messages over
   MAX_MESSAGE_SIZE (#1204).
+
+* AMQPOutput now uses defined constants for delivery mode instead of hard
+  coded (and wrong) integer values (#1235).
 
 Features
 --------
@@ -61,10 +62,40 @@ Features
 
 * Added `send_interval` setting to SmtpOutput.
 
+* Added `timestamp` format setting to ESLogstashV0Encoder (#1142).
+
+* LogstreamerInput now uses first two "magic" bytes to identify gzip files
+  instead of relying on `.gz` suffix.
+
+* Added TLS support to ElasticSearchOutput (#1259).
+
+* Added ability for HttpListenInput to capture specified HTTP request headers
+  and write them as message fields.
+  
 * Added ability for Statsd input handler to treat a malformed stat line 
   one at time without skipping all the "good" stats in a multi-line input
   (more like statsd itself).
   
+0.8.3 (2015-01-08)
+==================
+
+Bug Handling
+------------
+
+* Fixed LogstreamerInput to use a separate DecoderRunner for every
+  LogstreamInput created, rather than sending all of the streams through a
+  single decoder.
+
+0.8.2 (2015-01-06)
+==================
+
+Bug Handling
+------------
+
+* Fix rsyslog sandbox decoder test to use current year and location for
+  timestamp parsing, since syslog timestamp format makes that assumption.
+
+* Ensure that geoip_decoder is not included in release binaries.
 
 0.8.1 (2014-12-17)
 ==================

--- a/plugins/statsd/statsd_input.go
+++ b/plugins/statsd/statsd_input.go
@@ -32,14 +32,14 @@ import (
 // via a configured StatFilter plugin) over the exposed `Packet` channel. It
 // currently doesn't support Sets or other metric types.
 type StatsdInput struct {
-	name		  string
-	listener	  net.Conn
-	stopChan	  chan bool
-	statChan	  chan<- Stat
-	statAccumName string
-	statAccum	 StatAccumulator
-	maxMsgSize	uint
-	ir			InputRunner
+	name             string
+	listener         net.Conn
+	stopChan         chan bool
+	statChan         chan<- Stat
+	statAccumName    string
+	statAccum        StatAccumulator
+	maxMsgSize       uint
+	ir               InputRunner
 }
 
 // StatsInput config struct
@@ -58,9 +58,9 @@ type StatsdInputConfig struct {
 
 func (s *StatsdInput) ConfigStruct() interface{} {
 	return &StatsdInputConfig{
-		Address:	   "127.0.0.1:8125",
+		Address:       "127.0.0.1:8125",
 		StatAccumName: "StatAccumInput",
-		MaxMsgSize: 512,
+		MaxMsgSize:    512,
 	}
 }
 

--- a/plugins/statsd/statsd_input.go
+++ b/plugins/statsd/statsd_input.go
@@ -153,6 +153,9 @@ func parseMessage(message []byte) ([]Stat, error) {
 	}
 
 	for _, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
 		colonPos := bytes.IndexByte(line, ':')
 		if colonPos == -1 {
 			return nil, fmt.Errorf(errFmt, line)

--- a/plugins/statsd/statsd_input.go
+++ b/plugins/statsd/statsd_input.go
@@ -137,7 +137,7 @@ func (s *StatsdInput) handleMessage(message []byte) {
 
 	for _, stat := range stats {
 		if !s.statAccum.DropStat(stat) {
-			s.ir.LogError(fmt.Errorf("Undelivered stat: %s", stat))
+			s.ir.LogError(fmt.Errorf("Undelivered stat: %+v", stat))
 		}
 	}
 }

--- a/plugins/statsd/statsd_input.go
+++ b/plugins/statsd/statsd_input.go
@@ -32,14 +32,14 @@ import (
 // via a configured StatFilter plugin) over the exposed `Packet` channel. It
 // currently doesn't support Sets or other metric types.
 type StatsdInput struct {
-	name             string
-	listener         net.Conn
-	stopChan         chan bool
-	statChan         chan<- Stat
-	statAccumName    string
-	statAccum        StatAccumulator
-	maxMsgSize       uint
-	ir               InputRunner
+	name          string
+	listener      net.Conn
+	stopChan      chan bool
+	statChan      chan<- Stat
+	statAccumName string
+	statAccum     StatAccumulator
+	maxMsgSize    uint
+	ir            InputRunner
 }
 
 // StatsInput config struct
@@ -90,8 +90,8 @@ func (s *StatsdInput) Run(ir InputRunner, h PluginHelper) (err error) {
 
 	// Spin up the UDP listener.
 	var (
-		n	   int
-		e	   error
+		n       int
+		e       error
 		stopped bool
 	)
 	defer s.listener.Close()

--- a/plugins/statsd/statsd_input_test.go
+++ b/plugins/statsd/statsd_input_test.go
@@ -166,8 +166,16 @@ func TestParseMessage(t *testing.T) {
 	}
 
 	for msg, expected := range testData {
-		obtained, _, err := parseMessage([]byte(msg + "\n"))
-
+		obtained, warn, err := parseMessage([]byte(msg + "\n"))
+	
+		if warn != nil {
+			t.Fatalf("warning should be nil, got %s", warn)
+		}
+		
+		if err != nil {
+			t.Fatalf("error should be nil, got %s", err)
+		}
+		
 		if err != nil {
 			t.Fatalf("error should be nil, got %s", err)
 		}

--- a/plugins/statsd/statsd_input_test.go
+++ b/plugins/statsd/statsd_input_test.go
@@ -166,7 +166,7 @@ func TestParseMessage(t *testing.T) {
 	}
 
 	for msg, expected := range testData {
-		obtained, err := parseMessage([]byte(msg + "\n"))
+		obtained, warn, err := parseMessage([]byte(msg + "\n"))
 
 		if err != nil {
 			t.Fatalf("error should be nil, got %s", err)
@@ -204,7 +204,7 @@ func TestParseMessageInvalid(t *testing.T) {
 	}
 
 	for _, m := range messages {
-		_, err := parseMessage([]byte(m + "\n"))
+		_, warn, err := parseMessage([]byte(m + "\n"))
 
 		if err == nil {
 			t.Fatalf("err should not be nil, got : %s", err.Error())

--- a/plugins/statsd/statsd_input_test.go
+++ b/plugins/statsd/statsd_input_test.go
@@ -166,7 +166,7 @@ func TestParseMessage(t *testing.T) {
 	}
 
 	for msg, expected := range testData {
-		obtained, warn, err := parseMessage([]byte(msg + "\n"))
+		obtained, _, err := parseMessage([]byte(msg + "\n"))
 
 		if err != nil {
 			t.Fatalf("error should be nil, got %s", err)
@@ -204,7 +204,7 @@ func TestParseMessageInvalid(t *testing.T) {
 	}
 
 	for _, m := range messages {
-		_, warn, err := parseMessage([]byte(m + "\n"))
+		_, _, err := parseMessage([]byte(m + "\n"))
 
 		if err == nil {
 			t.Fatalf("err should not be nil, got : %s", err.Error())


### PR DESCRIPTION
Some statsd emitters put a double \n\n in the output of multi line statsd stats.  This causes the entire message to be treated as failed, when there is an easy fix here.  Same behavior as statsd itself https://github.com/etsy/statsd/blob/master/stats.js line  205 or so.