### PR TITLE
Detect gzip files using the first two magic bytes in the file

### DIFF
--- a/logstreamer/reader.go
+++ b/logstreamer/reader.go
@@ -22,10 +22,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/mozilla-services/heka/ringbuf"
 	"io"
 	"os"
-	"strings"
+
+	"github.com/mozilla-services/heka/ringbuf"
 )
 
 // A location in a logstream indicating the farthest that has been read
@@ -327,10 +327,21 @@ func createFileReader(path string, fd *os.File) (reader io.Reader, err error) {
 	return
 }
 
-// Guesses if the given file is gzipped. Currently this uses the filename,
-// but it could sniff the file header.
+// Guesses if the given file is gzipped.
 func isGzipFile(path string) bool {
-	return strings.HasSuffix(path, ".gz")
+	file, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+
+	magic := make([]byte, 2)
+	numbytes, err := file.Read(magic)
+	if numbytes != 2 || err != nil {
+		return false
+	}
+
+	return (magic[0] == 0x1f && magic[1] == 0x8b)
 }
 
 var ErrorCantSeekPosition = errors.New("Unable to locate position")


### PR DESCRIPTION
(http://en.wikipedia.org/wiki/Gzip#File_format) instead of relying on
the file name ending in .gz.

This makes it possible to use heka with svlogd (part of runit), when
svlogd compresses older log files, as svlogd does not change the
original file name.