### PR TITLE
add tls support to ES

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,8 @@
 0.9.0 (2014-MM-DD)
 ==================
 
+* Added TLS support to ElasticSearchOutput (#1259).
+
 Backwards Incompatibilities
 ---------------------------
 

--- a/docs/source/config/outputs/elasticsearch.rst
+++ b/docs/source/config/outputs/elasticsearch.rst
@@ -41,6 +41,13 @@ Config:
     The password to use for HTTP authentication against the ElasticSearch host.
     Defaults to "" (i. e. no authentication).
 
+.. versionadded:: 0.9
+
+- tls (TlsConfig):
+    An optional sub-section that specifies the settings to be used for any
+    SSL/TLS encryption. This will only have any impact if `URL` uses the
+    `HTTPS` URI scheme. See :ref:`tls`.
+
 Example:
 
 .. code-block:: ini


### PR DESCRIPTION
This code is very similar to the way AMQP plugin works.  It checks to see if the server is using https protocol.  If so, TLS is enabled.  Currently, ES does not support TLS on its own, but TLS can be accomplished by proxying it with Apache or Nginx.

There will be another product of ES in the future called the Shield which will support TLS (and other security related stuff).  Presumably this code will also work for people who decide to use Shield.

http://www.elasticsearch.org/overview/shield