### PR TITLE
HttpListenInput: Add ability to include headers as fields

### DIFF
--- a/docs/source/config/inputs/httplisten.rst
+++ b/docs/source/config/inputs/httplisten.rst
@@ -42,6 +42,9 @@ Config:
     Specifies whether or not the received request body will be URL unescaped
     before being written to the message payload. Defaults to true.
 
+- request_headers ([]string):
+    Add additional request headers as message fields. Defaults to empty list.
+
 Example:
 
 .. code-block:: ini


### PR DESCRIPTION
Follow-up to #1267

This PR makes it possible to include http request headers in HttpListenInput. If the configured headers are found, they are added as message fields.

(I also cleaned up the logging a bit since hli.ir.LogMessage already prefix the log message with the plugin name.)