### PR TITLE
HttpListenInput: document query parameter feature

### DIFF
--- a/docs/source/config/inputs/httplisten.rst
+++ b/docs/source/config/inputs/httplisten.rst
@@ -20,6 +20,12 @@ as the message payload. Messages will be populated as follows:
 - Fields["Protocol"] (string): HTTP protocol used for the request (e.g.
                                "HTTP/1.0")
 
+.. versionadded:: 0.6
+
+All query parameters are added as fields. For example, a request to
+"127.0.0.1:8325?user=bob" will create a field "user" with the value
+"bob".
+
 Config:
 
 - address (string):


### PR DESCRIPTION
The query parameter feature was added to Heka 0.6, but is not mentioned in the docs. 