### PR TITLE
SmtpOutput: encode email subject with base64

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -39,6 +39,8 @@ Bug Handling
 * Hekad now respects --config parameter and loads default config path
   instead of printing help and exit (#1239).
 
+* SmtpOutput now encodes email subject when necessary (#1277).
+
 Features
 --------
 

--- a/plugins/smtp/all_spec_test.go
+++ b/plugins/smtp/all_spec_test.go
@@ -1,0 +1,30 @@
+/***** BEGIN LICENSE BLOCK *****
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# The Initial Developer of the Original Code is the Mozilla Foundation.
+# Portions created by the Initial Developer are Copyright (C) 2012
+# the Initial Developer. All Rights Reserved.
+#
+# Contributor(s):
+#   Rob Miller (rmiller@mozilla.com)
+#
+# ***** END LICENSE BLOCK *****/
+
+package smtp
+
+import (
+	"github.com/rafrombrc/gospec/src/gospec"
+	"testing"
+)
+
+func TestAllSpecs(t *testing.T) {
+	r := gospec.NewRunner()
+	r.Parallel = false
+
+	r.AddSpec(EncoderSpec)
+	r.AddSpec(SmtpOutputSpec)
+
+	gospec.MainGoTest(r, t)
+}

--- a/plugins/smtp/encoder.go
+++ b/plugins/smtp/encoder.go
@@ -1,0 +1,138 @@
+/***** BEGIN LICENSE BLOCK *****
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# The Initial Developer of the Original Code is the Mozilla Foundation.
+# Portions created by the Initial Developer are Copyright (C) 2012-2014
+# the Initial Developer. All Rights Reserved.
+#
+# Contributor(s):
+#   Rob Miller (rmiller@mozilla.com)
+#   Kun Liu (git@lk.vc)
+#
+# ***** END LICENSE BLOCK *****/
+
+package smtp
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// Each line of characters SHOULD be no more than 78 characters, excluding
+// the CRLF. (RFC 2822 2.1.1)
+const EMAIL_LINE_LENGTH = 78
+
+func encodeBase64LimitChars(source string, limit int) (encoded string, numOfSourceChars int) {
+	numOfSourceChars = limit / 4 * 3
+	if len(source) <= numOfSourceChars {
+		encoded = base64.StdEncoding.EncodeToString([]byte(source))
+		numOfSourceChars = len(source)
+	} else {
+		for numOfSourceChars > 0 && !utf8.RuneStart(source[numOfSourceChars]) {
+			numOfSourceChars--
+		}
+		if numOfSourceChars > 0 {
+			encoded = base64.StdEncoding.EncodeToString([]byte(source[:numOfSourceChars]))
+		}
+	}
+	return
+}
+
+func encodeQuoPriByte(dst []byte, b byte) int {
+	dst[0] = '='
+	dst[1] = fmt.Sprintf("%X", b>>4)[0]
+	dst[2] = fmt.Sprintf("%X", b&0xf)[0]
+	return 3
+}
+
+func encodeQuoPriLimitChars(source string, limit int) (encoded string, numOfSourceChars int) {
+	buf := make([]byte, limit)
+	var length int = 0
+	for i := 0; i < len(source) && length < limit; {
+		b := source[i]
+		// 8-bit values which correspond to printable ASCII characters other
+		// than "=", "?", and "_" (underscore), MAY be represented as those
+		// characters. (RFC 2047 4.2.3)
+		if b >= ' ' && b <= '~' && b != '=' && b != '?' && b != '_' {
+			numOfSourceChars++
+			if b == ' ' {
+				buf[length] = '_' // RFC 2047 4.2.2
+			} else {
+				buf[length] = b
+			}
+			length++
+			i++
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(source[i:])
+		if r == utf8.RuneError {
+			i++
+			numOfSourceChars++
+		} else if size <= 0 {
+			break
+		} else {
+			if length+size*3 > limit {
+				break
+			}
+			i += size
+			numOfSourceChars += size
+			for j := 0; j < size; j++ {
+				length += encodeQuoPriByte(buf[length:], source[i+j])
+			}
+		}
+	}
+	return string(buf[:length]), numOfSourceChars
+}
+
+func isPrintableAscii(s string) bool {
+	for _, c := range s {
+		if c < ' ' || c > '~' {
+			return false
+		}
+	}
+	return true
+}
+
+func encodedField(field, s string) string {
+	// only support 'Subject' field for now
+	total := len(s)
+	fieldNameLength := len(field) + 1 // ex. Subject:
+	if total <= 0 || (total <= EMAIL_LINE_LENGTH-fieldNameLength-1 && isPrintableAscii(s)) {
+		// no need encoding
+		return field + ": " + s
+	}
+	// if needs encoding, resulting string will look like
+	//   =?utf-8?B?5ZOI5ZOI77yM5oiR5piv5YiY5piG44CCMTIz?=\r\n
+	//   =?utf-8?Q?_Hello!?=
+	processed := 0
+	lines := make([]string, 0, 1+len(s)/EMAIL_LINE_LENGTH)
+	for processed < total {
+		limit := EMAIL_LINE_LENGTH - fieldNameLength - len(" =?utf-8?B??=")
+		fieldNameLength = 0 // only the first line has field name
+		bStr, bNum := encodeBase64LimitChars(s[processed:], limit)
+		qStr, qNum := encodeQuoPriLimitChars(s[processed:], limit)
+		if bNum <= 0 && qNum <= 0 {
+			// something wrong?
+			return field + ": " + s
+		}
+		// use the most efficient encoding
+		if qNum >= bNum {
+			lines = append(lines, strings.Join([]string{" =", "utf-8", "Q", qStr, "="}, "?"))
+			processed += qNum
+		} else {
+			lines = append(lines, strings.Join([]string{" =", "utf-8", "B", bStr, "="}, "?"))
+			processed += bNum
+		}
+	}
+	// each line of `lines` already has space as first character,
+	// so use ":" instead of ": "
+	return field + ":" + strings.Join(lines, "\r\n")
+}
+
+func encodeSubject(s string) string {
+	return encodedField("Subject", s)
+}

--- a/plugins/smtp/encoder_test.go
+++ b/plugins/smtp/encoder_test.go
@@ -1,0 +1,78 @@
+/***** BEGIN LICENSE BLOCK *****
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# The Initial Developer of the Original Code is the Mozilla Foundation.
+# Portions created by the Initial Developer are Copyright (C) 2012
+# the Initial Developer. All Rights Reserved.
+#
+# Contributor(s):
+#   Kun Liu (git@lk.vc)
+#
+# ***** END LICENSE BLOCK *****/
+
+package smtp
+
+import (
+	gs "github.com/rafrombrc/gospec/src/gospec"
+)
+
+func EncoderSpec(c gs.Context) {
+
+	c.Specify("Base64 Encoding", func() {
+		c.Specify("limit output length", func() {
+			str, num := encodeBase64LimitChars("Hello", 7)
+			c.Expect(num, gs.Equals, 3)
+			c.Expect(str, gs.Equals, "SGVs")
+		})
+		c.Specify("source within limit", func() {
+			str, num := encodeBase64LimitChars("Hello", 80)
+			c.Expect(num, gs.Equals, 5)
+			c.Expect(str, gs.Equals, "SGVsbG8=")
+		})
+		c.Specify("utf-8 skip half rune", func() {
+			str, num := encodeBase64LimitChars("o测试", 8)
+			c.Expect(num, gs.Equals, 4)
+			c.Expect(str, gs.Equals, "b+a1iw==")
+		})
+	})
+
+	c.Specify("Quoted-printable Encoding", func() {
+		c.Specify("limit output length", func() {
+			str, num := encodeQuoPriLimitChars("Hello world", 7)
+			c.Expect(num, gs.Equals, 7)
+			c.Expect(str, gs.Equals, "Hello_w")
+		})
+		c.Specify("source within limit", func() {
+			str, num := encodeQuoPriLimitChars("Hello\r\n=?=_.", 80)
+			c.Expect(num, gs.Equals, 12)
+			c.Expect(str, gs.Equals, "Hello=0A=3D=3F=3D=5F=2E.")
+		})
+		c.Specify("utf-8 skip half rune", func() {
+			str, num := encodeQuoPriLimitChars("o测试", 12)
+			c.Expect(num, gs.Equals, 4)
+			c.Expect(str, gs.Equals, "o=E8=AF=95")
+		})
+	})
+
+	c.Specify("Subject Encoding", func() {
+		c.Specify("subject 1", func() {
+			str := encodeSubject("The ï, ö, ë, ä, and é work, \n" +
+				"but when adding the ü it doesn't.")
+			c.Expect(str, gs.Equals, "Subject: =?utf-8?B?VGhlIMOvLCDD"+
+				"tiwgw6ssIMOkLCBhbmQgw6kgd29yaywgCmJ1dCB3aGVu?=\r\n"+
+				" =?utf-8?Q?_adding_the_=20=69_it_doesn't.?=")
+		})
+		c.Specify("subject 2", func() {
+			str := encodeSubject("Hello world!")
+			c.Expect(str, gs.Equals, "Subject: Hello world!")
+		})
+		c.Specify("subject 3", func() {
+			str := encodeSubject("从前有座山，山里有座庙")
+			c.Expect(str, gs.Equals, "Subject: =?utf-8?B?"+
+				"5LuO5YmN5pyJ5bqn5bGx77yM5bGx6YeM5pyJ5bqn5bqZ?=")
+		})
+	})
+
+}

--- a/plugins/smtp/smtp_output.go
+++ b/plugins/smtp/smtp_output.go
@@ -164,7 +164,7 @@ func (s SmtpOutput) getHeader() []byte {
 	}
 	headers := make([]string, 5)
 	headers[0] = "From: " + s.conf.SendFrom
-	headers[1] = "Subject: " + subject
+	headers[1] = encodeSubject(subject)
 	headers[2] = "MIME-Version: 1.0"
 	headers[3] = "Content-Type: text/plain; charset=\"utf-8\""
 	headers[4] = "Content-Transfer-Encoding: base64"

--- a/plugins/smtp/smtp_output_test.go
+++ b/plugins/smtp/smtp_output_test.go
@@ -26,7 +26,6 @@ import (
 	gs "github.com/rafrombrc/gospec/src/gospec"
 	"net/smtp"
 	"sync"
-	"testing"
 	//"time"
 )
 
@@ -47,15 +46,6 @@ func testSendMail(addr string, a smtp.Auth, from string, to []string, msg []byte
 	}
 	sendCount++
 	return nil
-}
-
-func TestAllSpecs(t *testing.T) {
-	r := gs.NewRunner()
-	r.Parallel = false
-
-	r.AddSpec(SmtpOutputSpec)
-
-	gs.MainGoTest(r, t)
 }
 
 func SmtpOutputSpec(c gs.Context) {

--- a/plugins/smtp/smtp_output_test.go
+++ b/plugins/smtp/smtp_output_test.go
@@ -99,6 +99,24 @@ func SmtpOutputSpec(c gs.Context) {
 		})
 	})
 
+	c.Specify("SmtpOutput Message Body Encoding", func() {
+		smtpOutput := new(SmtpOutput)
+		chars := "123456789012345678901234567890123456789012345678901234567"
+		charsE := "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3"
+		examples := [][]string{
+			{"Hello", "SGVsbG8="},
+			{chars, charsE},
+			{chars + chars, charsE + "\r\n" + charsE},
+			{chars + chars + "Hello", charsE + "\r\n" + charsE + "\r\n" + "SGVsbG8="},
+			{"", ""},
+			{"1", "MQ=="},
+		}
+		for _, example := range examples {
+			smtpOutput.encodeFullMsg([]byte(example[0]))
+			c.Expect(string(smtpOutput.fullMsg), gs.Equals, example[1])
+		}
+	})
+
 	// // Use this test with a real server
 	// c.Specify("Real SmtpOutput output", func() {
 	// 	smtpOutput := new(SmtpOutput)


### PR DESCRIPTION
Email headers must contain only ASCII characters.
http://ncona.com/2011/06/using-utf-8-characters-on-an-e-mail-subject/