### PR TITLE
Treat gauges as floats for statsd input, fixes #850

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -22,6 +22,9 @@ Backwards Incompatibilities
 * Hekad and all clients started using stdio for informational messages and
   stderr for error messages.
 
+* Stats Accum Input treats gauge inputs as float64 rather than int64 to match
+  statsd spec and other statsd implementations (#850).
+
 Bug Handling
 ------------
 

--- a/pipeline/stat_accum_input_test.go
+++ b/pipeline/stat_accum_input_test.go
@@ -175,8 +175,8 @@ func StatAccumInputSpec(c gs.Context) {
 					sendGauge("sample2.gauge", 1, 2, 3, 4, 5)
 					msg, err := finalizeSendingStats()
 					c.Assume(err, gs.IsNil)
-					validateValueAtKey(msg, "stats.gauges.sample.gauge", int64(2))
-					validateValueAtKey(msg, "stats.gauges.sample2.gauge", int64(5))
+					validateValueAtKey(msg, "stats.gauges.sample.gauge", float64(2))
+					validateValueAtKey(msg, "stats.gauges.sample2.gauge", float64(5))
 				})
 
 				c.Specify("emits correct statsd.numStats count", func() {
@@ -207,7 +207,7 @@ func StatAccumInputSpec(c gs.Context) {
 
 					msg, err := finalizeSendingStats()
 					c.Assume(err, gs.IsNil)
-					validateValueAtKey(msg, "stats.gauges.sample.gauge", int64(2))
+					validateValueAtKey(msg, "stats.gauges.sample.gauge", float64(2))
 					validateValueAtKey(msg, "stats.counters.sample.cnt.count", int64(0))
 					validateValueAtKey(msg, "stats.timers.sample.timer.count", int64(0))
 					validateValueAtKey(msg, "stats.statsd.numStats", int64(3))


### PR DESCRIPTION
For issue #850 based on @alexzorkin changes, just added a line to CHANGES.txt and did not change the print format line. I believe the %f is the correct format type to use in this case.