### PR TITLE
delete field values through write_message with nil, fixes #842

### DIFF
--- a/message/message.go
+++ b/message/message.go
@@ -259,6 +259,19 @@ func (m *Message) AddField(f *Field) {
 	m.Fields[l] = f
 }
 
+// Deletes a Field from the message
+func (m *Message) DeleteField(f *Field) {
+	if m == nil {
+		return
+	}
+	for i, v := range m.Fields {
+		if v == f {
+			m.Fields = append(m.Fields[:i], m.Fields[i+1:]...)
+			break
+		}
+	}
+}
+
 // Field constructor
 func NewField(name string, value interface{}, representation string) (f *Field, err error) {
 	v := reflect.ValueOf(value)

--- a/sandbox/lua/lua_sandbox.go.in
+++ b/sandbox/lua/lua_sandbox.go.in
@@ -204,6 +204,60 @@ func write_to_field(msg *message.Message, fn string, value interface{}, rep *C.c
 	return nil
 }
 
+// Enforces field and array index limits.
+func delete_field(msg *message.Message, fn string, fi, ai int, has_ai bool) error {
+
+	var field *message.Field
+	fields := msg.FindAllFields(fn)
+
+	// We're only allowed to delete existing fields
+	if len(fields) == 0 {
+		return errors.New("bad field name")
+	}
+	if fi > len(fields) {
+		return errors.New("bad field index")
+	}
+
+	field = fields[fi]
+	if has_ai {
+		switch field.GetValueType() {
+		case message.Field_STRING:
+			if ai > len(field.ValueString) {
+				return errors.New("bad array index")
+			} else {
+				field.ValueString = append(field.ValueString[:ai], field.ValueString[ai+1:]...)
+			}
+		case message.Field_BYTES:
+			if ai > len(field.ValueBytes) {
+				return errors.New("bad array index")
+			} else {
+				field.ValueBytes = append(field.ValueBytes[:ai], field.ValueBytes[ai+1:]...)
+			}
+		case message.Field_INTEGER:
+			if ai > len(field.ValueInteger) {
+				return errors.New("bad array index")
+			} else {
+				field.ValueInteger = append(field.ValueInteger[:ai], field.ValueInteger[ai+1:]...)
+			}
+		case message.Field_DOUBLE:
+			if ai > len(field.ValueDouble) {
+				return errors.New("bad array index")
+			} else {
+				field.ValueDouble = append(field.ValueDouble[:ai], field.ValueDouble[ai+1:]...)
+			}
+		case message.Field_BOOL:
+			if ai > len(field.ValueBool) {
+				return errors.New("bad array index")
+			} else {
+				field.ValueBool = append(field.ValueBool[:ai], field.ValueBool[ai+1:]...)
+			}
+		}
+	} else {
+		msg.DeleteField(field)
+	}
+	return nil
+}
+
 //export go_lua_read_message
 func go_lua_read_message(ptr unsafe.Pointer, c *C.char, fi, ai int) (int, unsafe.Pointer,
 	int) {
@@ -426,6 +480,31 @@ func go_lua_write_message_bool(ptr unsafe.Pointer, c *C.char, v bool, rep *C.cha
 		return 0
 	}
 	lsb.globals.LogMessage("go_lua_write_message_bool", "Bad field name.")
+	return 1
+}
+
+//export go_lua_delete_message_field
+func go_lua_delete_message_field(ptr unsafe.Pointer, c *C.char, fi, ai int, has_ai bool) int {
+
+	fieldName := C.GoString(c)
+	var lsb *LuaSandbox = (*LuaSandbox)(ptr)
+	if lsb.pack == nil {
+		lsb.globals.LogMessage("go_lua_delete_message_field", "No sandbox pack.")
+		return 1
+	}
+	if !lsb.messageCopied && lsb.pluginType == "encoder" {
+		lsb.pack.Message = message.CopyMessage(lsb.pack.Message)
+		lsb.messageCopied = true
+	}
+
+	if fn, found := extractLuaFieldName(fieldName); found {
+		if err := delete_field(lsb.pack.Message, fn, fi, ai, has_ai); err != nil {
+			lsb.globals.LogMessage("go_lua_delete_message_field", err.Error())
+			return 1
+		}
+		return 0
+	}
+	lsb.globals.LogMessage("go_lua_delete_message_field", "Bad field name.")
 	return 1
 }
 

--- a/sandbox/lua/lua_sandbox_interface.c
+++ b/sandbox/lua/lua_sandbox_interface.c
@@ -232,6 +232,7 @@ int write_message(lua_State* lua)
     luaL_argcheck(lua, fi >= 0, 4, "field index must be >= 0");
     int ai = luaL_optinteger(lua, 5, 0);
     luaL_argcheck(lua, ai >= 0, 5, "array index must be >= 0");
+    int has_ai = !lua_isnoneornil(lua, 5); // needed for deletion
 
     int result;
 
@@ -256,6 +257,10 @@ int write_message(lua_State* lua)
         const char* value = lua_tostring(lua, 2);
         result = go_lua_write_message_string(lsb_get_parent(lsb), (char*)field,
             (char*)value, (char*)rep, fi, ai);
+        break;
+    }
+    case LUA_TNIL: {
+        result = go_lua_delete_message_field(lsb_get_parent(lsb), (char*)field, fi, ai, has_ai);
         break;
     }
     default:

--- a/sandbox/lua/lua_sandbox_test.go
+++ b/sandbox/lua/lua_sandbox_test.go
@@ -356,7 +356,6 @@ func TestWriteMessageErrors(t *testing.T) {
 		"Negative field index",
 		"Negative array index",
 		"nil field",
-		"nil value",
 		"empty uuid",
 		"invalid uuid",
 		"empty timestamp",
@@ -374,13 +373,12 @@ func TestWriteMessageErrors(t *testing.T) {
 		"process_message() ./testsupport/write_message_errors.lua:23: bad argument #4 to 'write_message' (field index must be >= 0)",
 		"process_message() ./testsupport/write_message_errors.lua:25: bad argument #5 to 'write_message' (array index must be >= 0)",
 		"process_message() ./testsupport/write_message_errors.lua:27: bad argument #1 to 'write_message' (string expected, got nil)",
-		"process_message() ./testsupport/write_message_errors.lua:29: write_message() only accepts numeric, string, or boolean field values",
+		"process_message() ./testsupport/write_message_errors.lua:29: write_message() failed",
 		"process_message() ./testsupport/write_message_errors.lua:31: write_message() failed",
 		"process_message() ./testsupport/write_message_errors.lua:33: write_message() failed",
 		"process_message() ./testsupport/write_message_errors.lua:35: write_message() failed",
 		"process_message() ./testsupport/write_message_errors.lua:37: write_message() failed",
 		"process_message() ./testsupport/write_message_errors.lua:39: write_message() failed",
-		"process_message() ./testsupport/write_message_errors.lua:41: write_message() failed",
 	}
 
 	var sbc SandboxConfig

--- a/sandbox/lua/testsupport/write_message_decoder.lua
+++ b/sandbox/lua/testsupport/write_message_decoder.lua
@@ -29,5 +29,17 @@ function process_message ()
 		write_message("Fields[array]", "first", "", 0, 0)
 		write_message("Fields[array]", "second", "", 0, 1)
 	end
+	if msg == "delete field scribble" then
+		write_message("Fields[scribble]", nil)
+	end
+	if msg == "delete second field of multi" then
+		write_message("Fields[multi]", nil, "", 1)
+	end
+	if msg == "delete second value of array" then
+		write_message("Fields[array]", "first", "", 0, 0)
+		write_message("Fields[array]", "second", "", 0, 1)
+		write_message("Fields[array]", "third", "", 0, 2)
+		write_message("Fields[array]", nil, "", 0, 1)
+	end
 	return 0
 end

--- a/sandbox/lua/testsupport/write_message_errors.lua
+++ b/sandbox/lua/testsupport/write_message_errors.lua
@@ -25,8 +25,6 @@ function process_message ()
         write_message("Fields[bogus]", 0, "count", 0, -1)
     elseif msg == "nil field" then
         write_message(nil, 0)
-    elseif msg == "nil value" then
-        write_message("Severity", nil)
     elseif msg == "empty uuid" then
         write_message("Uuid", "")
     elseif msg == "invalid uuid" then

--- a/sandbox/plugins/sandbox_decoders_test.go
+++ b/sandbox/plugins/sandbox_decoders_test.go
@@ -190,6 +190,54 @@ func DecoderSpec(c gs.Context) {
 				c.Expect(values[0], gs.Equals, "first")
 				c.Expect(values[1], gs.Equals, "second")
 			})
+
+			c.Specify("deletes a field from message", func() {
+				data := "delete field scribble"
+				pack.Message.SetPayload(data)
+				f, _ := message.NewField("scribble", "asdf", "")
+				pack.Message.AddField(f)
+				decoder.Decode(pack)
+				fields := pack.Message.FindAllFields("scribble")
+				c.Expect(len(fields), gs.Equals, 0)
+				_, ok := pack.Message.GetFieldValue("scribble")
+				c.Expect(ok, gs.IsFalse)
+			})
+
+			c.Specify("deletes one of multiple field values", func() {
+				data := "delete second field of multi"
+				pack.Message.SetPayload(data)
+				f1, _ := message.NewField("multi", "first", "")
+				f2, _ := message.NewField("multi", "second", "")
+				f3, _ := message.NewField("multi", "third", "")
+				pack.Message.AddField(f1)
+				pack.Message.AddField(f2)
+				pack.Message.AddField(f3)
+				decoder.Decode(pack)
+				fields := pack.Message.FindAllFields("multi")
+				c.Expect(len(fields), gs.Equals, 2)
+				values := fields[0].GetValueString()
+				c.Expect(len(values), gs.Equals, 1)
+				c.Expect(values[0], gs.Equals, "first")
+				values = fields[1].GetValueString()
+				c.Expect(len(values), gs.Equals, 1)
+				c.Expect(values[0], gs.Equals, "third")
+				_, ok := pack.Message.GetFieldValue("multi")
+				c.Expect(ok, gs.IsTrue)
+			})
+
+			c.Specify("deletes one of multiple array values", func() {
+				data := "delete second value of array"
+				pack.Message.SetPayload(data)
+				decoder.Decode(pack)
+				fields := pack.Message.FindAllFields("array")
+				c.Expect(len(fields), gs.Equals, 1)
+				values := fields[0].GetValueString()
+				c.Expect(len(values), gs.Equals, 2)
+				c.Expect(values[0], gs.Equals, "first")
+				c.Expect(values[1], gs.Equals, "third")
+				_, ok := pack.Message.GetFieldValue("array")
+				c.Expect(ok, gs.IsTrue)
+			})
 		})
 	})
 


### PR DESCRIPTION
Allows deletion of field values in decoders through `write_message("fieldname", nil)`, as suggested in #842 

I implemented this as a workaround for #1295. With this PR a field can be overwritten by a value of different type by deleting it first.