### PR TITLE
Add TLS support for DockerLogInput

### DIFF
--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -163,7 +163,7 @@ if (INCLUDE_GEOIP)
 endif()
 
 if (INCLUDE_DOCKER_PLUGINS)
-    git_clone(https://github.com/rafrombrc/go-dockerclient 253de7054ca5defe718269e17732e24cdadc3d21)
+    git_clone(https://github.com/carlanton/go-dockerclient d408f209d5946d86da69382b3eb0a6faac7b3885)
 endif()
 
 if (INCLUDE_MOZSVC)

--- a/docs/source/config/inputs/docker_log.rst
+++ b/docs/source/config/inputs/docker_log.rst
@@ -26,6 +26,12 @@ Config:
     The name of the decoder used to further transform the message into a
     structured hekad message. No default decoder is specified.
 
+.. versionadded:: 0.9
+
+- cert_path (string, optional):
+    Path to directory containing client certificate and keys. This value works
+    in the same way as `DOCKER_CERT_PATH <https://docs.docker.com/articles/https/#client-modes>`_.
+
 Example:
 
 .. code-block:: ini

--- a/plugins/docker/attacher.go
+++ b/plugins/docker/attacher.go
@@ -25,10 +25,11 @@ package docker
 import (
 	"bufio"
 	"io"
+	"path/filepath"
 	"strings"
 	"sync"
 
-	"github.com/rafrombrc/go-dockerclient"
+	"github.com/carlanton/go-dockerclient"
 )
 
 type AttachEvent struct {
@@ -66,8 +67,19 @@ type AttachManager struct {
 	sentinel   struct{}
 }
 
-func NewAttachManager(endpoint string, attachErrors chan<- error) (*AttachManager, error) {
-	client, err := docker.NewClient(endpoint)
+func NewAttachManager(endpoint, certPath string, attachErrors chan<- error) (*AttachManager, error) {
+	var client DockerClient
+	var err error
+
+	if certPath == "" {
+		client, err = docker.NewClient(endpoint)
+	} else {
+		key := filepath.Join(certPath, "key.pem")
+		ca := filepath.Join(certPath, "ca.pem")
+		cert := filepath.Join(certPath, "cert.pem")
+		client, err = docker.NewTLSClient(endpoint, cert, key, ca)
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/docker/client.go
+++ b/plugins/docker/client.go
@@ -1,6 +1,6 @@
 package docker
 
-import "github.com/rafrombrc/go-dockerclient"
+import "github.com/carlanton/go-dockerclient"
 
 type DockerClient interface {
 	// AddEventListener adds a new listener to container events in the Docker
@@ -9,17 +9,10 @@ type DockerClient interface {
 	// The parameter is a channel through which events will be sent.
 	AddEventListener(listener chan<- *docker.APIEvents) error
 
-	RemoveEventListener(listener chan *docker.APIEvents) error
-
 	// ListContainersOptions specify parameters to the ListContainers function.
 	//
 	// See http://goo.gl/XqtcyU for more details.
 	ListContainers(opts docker.ListContainersOptions) ([]docker.APIContainers, error)
-
-	// ListImages returns the list of available images in the server.
-	//
-	// See http://goo.gl/VmcR6v for more details.
-	ListImages(all bool) ([]docker.APIImages, error)
 
 	// InspectContainer returns information about a container by its ID.
 	//
@@ -30,9 +23,4 @@ type DockerClient interface {
 	//
 	// See http://goo.gl/RRAhws for more details.
 	AttachToContainer(opts docker.AttachToContainerOptions) error
-
-	// Ping pings the docker server
-	//
-	// See http://goo.gl/stJENm for more details.
-	Ping() error
 }

--- a/plugins/docker/docker_log_input.go
+++ b/plugins/docker/docker_log_input.go
@@ -27,6 +27,7 @@ import (
 type DockerLogInputConfig struct {
 	// A Docker endpoint.
 	Endpoint string `toml:"endpoint"`
+	CertPath string `toml:"cert_path"`
 }
 
 type DockerLogInput struct {
@@ -41,6 +42,7 @@ type DockerLogInput struct {
 func (di *DockerLogInput) ConfigStruct() interface{} {
 	return &DockerLogInputConfig{
 		Endpoint: "unix:///var/run/docker.sock",
+		CertPath: "",
 	}
 }
 
@@ -51,7 +53,7 @@ func (di *DockerLogInput) Init(config interface{}) error {
 	di.logstream = make(chan *Log)
 	di.attachErrors = make(chan error)
 
-	m, err := NewAttachManager(di.conf.Endpoint, di.attachErrors)
+	m, err := NewAttachManager(di.conf.Endpoint, di.conf.CertPath, di.attachErrors)
 	if err != nil {
 		return fmt.Errorf("DockerLogInput: failed to attach: %s", err.Error())
 	}


### PR DESCRIPTION
This solves #1279 

Support for TLS is now implemented in the upstream go-dockerclient. Unfortunately, they are nowadays depending on docker/docker and therefore also Sirupsen/logrus, meaning that we need to add those to externals.cmake if we want to use upstream. I think that is a bit silly, since we're only using a small fraction of the API.

Instead, I patched away the functions depending on it here: https://github.com/carlanton/go-dockerclient/commit/d408f209d5946d86da69382b3eb0a6faac7b3885