### PR TITLE
Adding functionality to the schema_influx.lua script to structure

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -85,6 +85,14 @@ Features
 
 * Added `message_interval` setting support to heka-flood test configuration.
 
+* Added an option to Schema InfluxDB Encoder to send the data to InfluxDB as
+  a list of series rather than the default of a single series for all fields
+  in the message.
+
+* Added an option to Schema InfluxDB Encoder that excludes all base fields
+  from being sent to InfluxDB to reduce the network traffic and storage
+  demands if these fields aren't useful.
+
 0.8.3 (2015-01-08)
 ==================
 


### PR DESCRIPTION
messages as an array of series as opposed to the default which is a
single series with each field as a separate column.  This is a
recommended format for performance reasons in v0.9.0+ as documented here:
http://influxdb.com/docs/v0.8/advanced_topics/schema_design.html#migration-to-0.9.0