### PR TITLE
Add a "reset" mechanism for SplitterRunners.

### DIFF
--- a/pipeline/splitter_runner.go
+++ b/pipeline/splitter_runner.go
@@ -40,7 +40,6 @@ type SplitterRunner interface {
 	KeepTruncated() bool
 	UseMsgBytes() bool
 	SetPackDecorator(decorator func(*PipelinePack))
-	ResetStream()
 }
 
 type sRunner struct {
@@ -83,13 +82,6 @@ func NewSplitterRunner(name string, splitter Splitter,
 	// be nil, which we test for later.
 	sr.unframer, _ = splitter.(UnframingSplitter)
 	return sr
-}
-
-func (sr *sRunner) ResetStream() {
-	sr.readPos = 0
-	sr.scanPos = 0
-	sr.needData = true
-	sr.reachedEOF = false
 }
 
 func (sr *sRunner) LogError(err error) {
@@ -207,7 +199,8 @@ func (sr *sRunner) GetRecordFromStream(r io.Reader) (bytesRead int, record []byt
 			// Reset reachedEOF so that if any new data is appended to the file,
 			// we can continue reading where we left off. Note that if you want
 			// to reuse this SplitterRunner on a different stream, you should
-			// call ResetStream() to clear any remaining data out of the buffer.
+			// call GetRemainingData() to clear any remaining data out of the
+			// buffer.
 			sr.reachedEOF = false
 		} else {
 			// If we haven't yet reached EOF, then we need to read more data.


### PR DESCRIPTION
In order to be able to reuse a SplitterRunner on a new stream, we need a mechanism to reset the state about the stream.

In order to "tail" a stream that could return EOF, but later have more data to read, we also reset the "reachedEOF" parameter after we return the final record in the stream. That will cause the next subsequent request for a record to re-read the underlying stream. Note that this is *not* sufficient for the "new stream" situation above, where we want to discard any leftover data (as well as state) from the previous stream.