### PR TITLE
Correct out of date Plugin descriptions in Glossary

### DIFF
--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -41,7 +41,8 @@ Glossary
 
     Plugin
         Hekad plugins are functional units that perform specific actions on or
-        with messages. 
+        with messages. There are six types of plugins: inputs, splitters, 
+        decoders, filters, encoders, and ouputs.
 
     PluginChanSize
         A Heka configuration setting which specifies the size of the input
@@ -55,10 +56,10 @@ Glossary
 
     PluginRunner
         A plugin-specific helper object that manages the lifespan of a given
-        plugin and handles most details of interaction w/ the greater Heka
-        environment. Comes in six variants, each tailored to a specific
-        plugin type (i.e. `InputRunner`, `SplitterRunner`, `DecoderRunner`, 
-        `FilterRunner`, `EncoderRunner`, `OutputRunner`).
+        plugin and handles most details of interaction with the greater Heka
+        environment. Comes in five variants, each tailored to a specific
+        plugin type: `InputRunner`, `SplitterRunner`, `DecoderRunner`, 
+        `FilterRunner`, and `OutputRunner`.
 
     PoolSize
         A Heka configuration setting which specifies the number of

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -41,8 +41,7 @@ Glossary
 
     Plugin
         Hekad plugins are functional units that perform specific actions on or
-        with messages. There are four distinct types of plugins: inputs,
-        decoders, filters, and outputs.
+        with messages. 
 
     PluginChanSize
         A Heka configuration setting which specifies the size of the input
@@ -57,9 +56,9 @@ Glossary
     PluginRunner
         A plugin-specific helper object that manages the lifespan of a given
         plugin and handles most details of interaction w/ the greater Heka
-        environment. Comes in four variants, each tailored to a specific
-        plugin type (i.e. `InputRunner`, `DecoderRunner`, `FilterRunner`,
-        `OutputRunner`).
+        environment. Comes in six variants, each tailored to a specific
+        plugin type (i.e. `InputRunner`, `SplitterRunner`, `DecoderRunner`, 
+        `FilterRunner`, `EncoderRunner`, `OutputRunner`).
 
     PoolSize
         A Heka configuration setting which specifies the number of


### PR DESCRIPTION
Fixes two references to there only being 4 types of plugins - looks like this predates Encoders and Splitters.