### PR TITLE
Enable AMQP input to use a read-only user

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -105,6 +105,8 @@ Features
 
 * Added `cert_path` setting for TLS support to DockerLogInput. 
 
+* Added `read_only` setting to AMQPInput to support read-only users.
+
 0.8.3 (2015-01-08)
 ==================
 

--- a/docs/source/config/inputs/amqp.rst
+++ b/docs/source/config/inputs/amqp.rst
@@ -57,6 +57,12 @@ Config:
     SSL/TLS encryption. This will only have any impact if `URL` uses the
     `AMQPS` URI scheme. See :ref:`tls`.
 
+.. versionadded:: 0.9
+
+- read_only (bool):
+    Whether the AMQP user is read-only. If this is true the exchange, queue
+    and binding must be declared before starting Heka. Defaults to false.
+
 Since many of these parameters have sane defaults, a minimal configuration to
 consume serialized messages would look like:
 


### PR DESCRIPTION
This adds a configuration option, ReadOnly, to AMQP input to
allow users which only have read access to connect to a queue.

The exchange, queue, and binding must be declared prior to
starting heka with a read-only user.

The config option defaults to false. Fixes #1314.