### PR TITLE
Fix Kafka behavior with manual offset when checkpoint file doesn't exist

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -31,6 +31,11 @@ Backwards Incompatibilities
 Bug Handling
 ------------
 
+* KafkaInput uses the oldest offset available instead of zero when no
+  checkpoint file exists and the offset method is set to manual. KafkaInput
+  also correctly closes the checkpoint file before removing it when it is
+  invalid (#1325).
+
 * Handle empty byte fields in the sandbox interface (#1284).
 
 * Reset header when discarding valid but oversized messages (#1221).

--- a/plugins/kafka/kafka_input_test.go
+++ b/plugins/kafka/kafka_input_test.go
@@ -79,6 +79,10 @@ func TestReceivePayloadMessage(t *testing.T) {
 	mdr.AddTopicPartition(topic, 0, 2)
 	b1.Returns(mdr)
 
+	or := new(sarama.OffsetResponse)
+	or.AddTopicPartition(topic, 0, 0)
+	b2.Returns(or)
+
 	fr := new(sarama.FetchResponse)
 	fr.AddMessage(topic, 0, nil, sarama.ByteEncoder([]byte{0x41, 0x42}), 0)
 	b2.Returns(fr)
@@ -178,6 +182,10 @@ func TestReceiveProtobufMessage(t *testing.T) {
 	mdr.AddBroker(b2.Addr(), b2.BrokerID())
 	mdr.AddTopicPartition(topic, 0, 2)
 	b1.Returns(mdr)
+
+	or := new(sarama.OffsetResponse)
+	or.AddTopicPartition(topic, 0, 0)
+	b2.Returns(or)
 
 	fr := new(sarama.FetchResponse)
 	fr.AddMessage(topic, 0, nil, sarama.ByteEncoder([]byte{0x41, 0x42}), 0)


### PR DESCRIPTION
An offset of 0 is not always valid, so use oldest instead.