### PR TITLE
plugin/amqp: expanded field coverage

### DIFF
--- a/plugins/amqp/amqp_input.go
+++ b/plugins/amqp/amqp_input.go
@@ -108,7 +108,7 @@ func (ai *AMQPInput) Init(config interface{}) (err error) {
 	}
 
 	if ai.amqpHub == nil {
-		ai.amqpHub = getAmqpHub()
+		ai.amqpHub = GetAmqpHub()
 	}
 	var dialer = AMQPDialer{tlsConf}
 	ch, usageWg, connWg, err := ai.amqpHub.GetChannel(conf.URL, dialer)

--- a/plugins/amqp/amqp_input.go
+++ b/plugins/amqp/amqp_input.go
@@ -276,7 +276,7 @@ func fieldMap(msg amqp.Delivery) map[string]interface{} {
 		"CorrelationId":   msg.CorrelationId,
 		"ReplyTo":         msg.ReplyTo,
 		"Expiration":      msg.Expiration,
-		"Type":            msg.Type,
+		"MessageType":     msg.Type,
 		"UserId":          msg.UserId,
 		"AppId":           msg.AppId,
 		"Exchange":        msg.Exchange,

--- a/plugins/amqp/amqp_output.go
+++ b/plugins/amqp/amqp_output.go
@@ -105,7 +105,7 @@ func (ao *AMQPOutput) Init(config interface{}) (err error) {
 
 	var dialer = AMQPDialer{tlsConf}
 	if ao.amqpHub == nil {
-		ao.amqpHub = getAmqpHub()
+		ao.amqpHub = GetAmqpHub()
 	}
 	ch, usageWg, connectionWg, err := ao.amqpHub.GetChannel(conf.URL, dialer)
 	if err != nil {

--- a/plugins/amqp/amqp_test.go
+++ b/plugins/amqp/amqp_test.go
@@ -166,7 +166,7 @@ func AMQPPluginSpec(c gs.Context) {
 				c.Assume(ok, gs.IsTrue)
 				c.Expect(fieldValue, gs.Equals, "1000")
 
-				fieldValue, ok = ith.Pack.Message.GetFieldValue("Type")
+				fieldValue, ok = ith.Pack.Message.GetFieldValue("MessageType")
 				c.Assume(ok, gs.IsTrue)
 				c.Expect(fieldValue, gs.Equals, "app-message")
 
@@ -271,7 +271,7 @@ func AMQPPluginSpec(c gs.Context) {
 				c.Assume(ok, gs.IsTrue)
 				c.Expect(fieldValue, gs.Equals, "1000")
 
-				fieldValue, ok = ith.Pack.Message.GetFieldValue("Type")
+				fieldValue, ok = ith.Pack.Message.GetFieldValue("MessageType")
 				c.Assume(ok, gs.IsTrue)
 				c.Expect(fieldValue, gs.Equals, "app-message")
 

--- a/plugins/amqp/amqp_test.go
+++ b/plugins/amqp/amqp_test.go
@@ -105,10 +105,20 @@ func AMQPPluginSpec(c gs.Context) {
 				ack := plugins_ts.NewMockAcknowledger(ctrl)
 				ack.EXPECT().Ack(gomock.Any(), false)
 				streamChan <- amqp.Delivery{
-					ContentType:  "text/plain",
-					Body:         []byte("This is a message"),
-					Timestamp:    time.Now(),
-					Acknowledger: ack,
+					ContentType:     "text/plain",
+					ContentEncoding: "utf-8",
+					Body:            []byte("This is a message"),
+					DeliveryMode:    1,
+					CorrelationId:   "foobar",
+					ReplyTo:         "foobaz",
+					Expiration:      "1000",
+					Type:            "app-message",
+					UserId:          "user-abc",
+					AppId:           "app-abc",
+					Timestamp:       time.Now(),
+					RoutingKey:      "testKey",
+					Exchange:        "testExchange",
+					Acknowledger:    ack,
 				}
 				mch.EXPECT().Consume("", "", false, false, false, false,
 					gomock.Any()).Return(streamChan, nil)
@@ -127,9 +137,54 @@ func AMQPPluginSpec(c gs.Context) {
 				ith.PackSupply <- ith.Pack
 				close(streamChan)
 				err = <-errChan
+
 				c.Expect(err, gs.IsNil)
 				c.Expect(ith.Pack.Message.GetType(), gs.Equals, "amqp")
 				c.Expect(ith.Pack.Message.GetPayload(), gs.Equals, "This is a message")
+
+				fieldValue, ok := ith.Pack.Message.GetFieldValue("ContentType")
+				c.Assume(ok, gs.IsTrue)
+				c.Expect(fieldValue, gs.Equals, "text/plain")
+
+				fieldValue, ok = ith.Pack.Message.GetFieldValue("ContentEncoding")
+				c.Assume(ok, gs.IsTrue)
+				c.Expect(fieldValue, gs.Equals, "utf-8")
+
+				fieldValueNum, ok := ith.Pack.Message.GetFieldValue("DeliveryMode")
+				c.Assume(ok, gs.IsTrue)
+				c.Expect(fieldValueNum, gs.Equals, int64(1))
+
+				fieldValue, ok = ith.Pack.Message.GetFieldValue("CorrelationId")
+				c.Assume(ok, gs.IsTrue)
+				c.Expect(fieldValue, gs.Equals, "foobar")
+
+				fieldValue, ok = ith.Pack.Message.GetFieldValue("ReplyTo")
+				c.Assume(ok, gs.IsTrue)
+				c.Expect(fieldValue, gs.Equals, "foobaz")
+
+				fieldValue, ok = ith.Pack.Message.GetFieldValue("Expiration")
+				c.Assume(ok, gs.IsTrue)
+				c.Expect(fieldValue, gs.Equals, "1000")
+
+				fieldValue, ok = ith.Pack.Message.GetFieldValue("Type")
+				c.Assume(ok, gs.IsTrue)
+				c.Expect(fieldValue, gs.Equals, "app-message")
+
+				fieldValue, ok = ith.Pack.Message.GetFieldValue("UserId")
+				c.Assume(ok, gs.IsTrue)
+				c.Expect(fieldValue, gs.Equals, "user-abc")
+
+				fieldValue, ok = ith.Pack.Message.GetFieldValue("AppId")
+				c.Assume(ok, gs.IsTrue)
+				c.Expect(fieldValue, gs.Equals, "app-abc")
+
+				fieldValue, ok = ith.Pack.Message.GetFieldValue("Exchange")
+				c.Assume(ok, gs.IsTrue)
+				c.Expect(fieldValue, gs.Equals, "testExchange")
+
+				fieldValue, ok = ith.Pack.Message.GetFieldValue("RoutingKey")
+				c.Assume(ok, gs.IsTrue)
+				c.Expect(fieldValue, gs.Equals, "testKey")
 			})
 		})
 
@@ -157,10 +212,20 @@ func AMQPPluginSpec(c gs.Context) {
 				ack := plugins_ts.NewMockAcknowledger(ctrl)
 				ack.EXPECT().Ack(gomock.Any(), false)
 				streamChan <- amqp.Delivery{
-					ContentType:  "text/plain",
-					Body:         []byte("This is a message"),
-					Timestamp:    time.Now(),
-					Acknowledger: ack,
+					ContentType:     "text/plain",
+					ContentEncoding: "utf-8",
+					Body:            []byte("This is a message"),
+					DeliveryMode:    1,
+					CorrelationId:   "foobar",
+					ReplyTo:         "foobaz",
+					Expiration:      "1000",
+					Type:            "app-message",
+					UserId:          "user-abc",
+					AppId:           "app-abc",
+					Timestamp:       time.Now(),
+					RoutingKey:      "testKey",
+					Exchange:        "testExchange",
+					Acknowledger:    ack,
 				}
 				mch.EXPECT().Consume("", "", false, false, false, false,
 					gomock.Any()).Return(streamChan, nil)
@@ -181,6 +246,50 @@ func AMQPPluginSpec(c gs.Context) {
 				err = <-errChan
 				c.Expect(ith.Pack.Message.GetType(), gs.Equals, "amqp")
 				c.Expect(ith.Pack.Message.GetPayload(), gs.Equals, "This is a message")
+
+				fieldValue, ok := ith.Pack.Message.GetFieldValue("ContentType")
+				c.Assume(ok, gs.IsTrue)
+				c.Expect(fieldValue, gs.Equals, "text/plain")
+
+				fieldValue, ok = ith.Pack.Message.GetFieldValue("ContentEncoding")
+				c.Assume(ok, gs.IsTrue)
+				c.Expect(fieldValue, gs.Equals, "utf-8")
+
+				fieldValueNum, ok := ith.Pack.Message.GetFieldValue("DeliveryMode")
+				c.Assume(ok, gs.IsTrue)
+				c.Expect(fieldValueNum, gs.Equals, int64(1))
+
+				fieldValue, ok = ith.Pack.Message.GetFieldValue("CorrelationId")
+				c.Assume(ok, gs.IsTrue)
+				c.Expect(fieldValue, gs.Equals, "foobar")
+
+				fieldValue, ok = ith.Pack.Message.GetFieldValue("ReplyTo")
+				c.Assume(ok, gs.IsTrue)
+				c.Expect(fieldValue, gs.Equals, "foobaz")
+
+				fieldValue, ok = ith.Pack.Message.GetFieldValue("Expiration")
+				c.Assume(ok, gs.IsTrue)
+				c.Expect(fieldValue, gs.Equals, "1000")
+
+				fieldValue, ok = ith.Pack.Message.GetFieldValue("Type")
+				c.Assume(ok, gs.IsTrue)
+				c.Expect(fieldValue, gs.Equals, "app-message")
+
+				fieldValue, ok = ith.Pack.Message.GetFieldValue("UserId")
+				c.Assume(ok, gs.IsTrue)
+				c.Expect(fieldValue, gs.Equals, "user-abc")
+
+				fieldValue, ok = ith.Pack.Message.GetFieldValue("AppId")
+				c.Assume(ok, gs.IsTrue)
+				c.Expect(fieldValue, gs.Equals, "app-abc")
+
+				fieldValue, ok = ith.Pack.Message.GetFieldValue("Exchange")
+				c.Assume(ok, gs.IsTrue)
+				c.Expect(fieldValue, gs.Equals, "testExchange")
+
+				fieldValue, ok = ith.Pack.Message.GetFieldValue("RoutingKey")
+				c.Assume(ok, gs.IsTrue)
+				c.Expect(fieldValue, gs.Equals, "testKey")
 			})
 
 			c.Specify("consumes a serialized message", func() {

--- a/plugins/amqp/types.go
+++ b/plugins/amqp/types.go
@@ -74,6 +74,11 @@ type AMQPDialer struct {
 	tlsConfig *tls.Config
 }
 
+// NewAMQPDialer exposes factory for AMQPDialers
+func NewAMQPDialer(tlsConfig *tls.Config) AMQPDialer {
+	return AMQPDialer{tlsConfig}
+}
+
 // If additional TLS settings were specified, the dialer uses amqp.DialTLS
 // instead of amqp.Dial.
 func (dialer *AMQPDialer) Dial(url string) (conn AMQPConnection, err error) {
@@ -112,7 +117,7 @@ func newAmqpHub() AMQPConnectionHub {
 	return ach
 }
 
-func getAmqpHub() AMQPConnectionHub {
+func GetAmqpHub() AMQPConnectionHub {
 	if amqpHub == nil {
 		amqpHub = newAmqpHub()
 	}


### PR DESCRIPTION
This PR contains a few tweaks I have made to the AMQP plugin to expand it's data coverage. It is functional, but not data-complete; AMQP headers are not (yet) included as heka field(s). This is something I need, but I would like it to be implemented in idiomatic heka so I am open to suggestions on the best way to approach this.

#### Change Summary:

* `plugins/amqp/type.go`: Expose dialer and hub to allow for further custom AMQP plugins based on same connection methodology.
* `plugins/amqp/input.go`: Include most AMQP meta data as Heka message field. 