### PR TITLE
plugins[amqp]: expose "types" hub and dialer methods

### DIFF
--- a/plugins/amqp/amqp_input.go
+++ b/plugins/amqp/amqp_input.go
@@ -103,9 +103,9 @@ func (ai *AMQPInput) Init(config interface{}) (err error) {
 	}
 
 	if ai.amqpHub == nil {
-		ai.amqpHub = getAmqpHub()
+		ai.amqpHub = GetAmqpHub()
 	}
-	var dialer = AMQPDialer{tlsConf}
+	var dialer = NewAMQPDialer(tlsConf)
 	ch, usageWg, connWg, err := ai.amqpHub.GetChannel(conf.URL, dialer)
 	if err != nil {
 		return

--- a/plugins/amqp/amqp_output.go
+++ b/plugins/amqp/amqp_output.go
@@ -103,9 +103,9 @@ func (ao *AMQPOutput) Init(config interface{}) (err error) {
 		}
 	}
 
-	var dialer = AMQPDialer{tlsConf}
+	var dialer = NewAMQPDialer(tlsConf)
 	if ao.amqpHub == nil {
-		ao.amqpHub = getAmqpHub()
+		ao.amqpHub = GetAmqpHub()
 	}
 	ch, usageWg, connectionWg, err := ao.amqpHub.GetChannel(conf.URL, dialer)
 	if err != nil {

--- a/plugins/amqp/types.go
+++ b/plugins/amqp/types.go
@@ -66,6 +66,11 @@ type AMQPConnectionTracker struct {
 	connWg  *sync.WaitGroup
 }
 
+// NewAMQPDialer exposes factory for AMQPDialers
+func NewAMQPDialer(tlsConfig *tls.Config) AMQPDialer {
+	return AMQPDialer{tlsConfig}
+}
+
 // AMQP connection dialer
 type AMQPDialer struct {
 	tlsConfig *tls.Config
@@ -109,7 +114,7 @@ func newAmqpHub() AMQPConnectionHub {
 	return ach
 }
 
-func getAmqpHub() AMQPConnectionHub {
+func GetAmqpHub() AMQPConnectionHub {
 	if amqpHub == nil {
 		amqpHub = newAmqpHub()
 	}


### PR DESCRIPTION
- `AMQPDialer{tlsConfig}` => `NewAMQPDialer(tlsConfig)`
- `getAmqpHub()` => `GetAmqpHub()`

By exposing this functionality, custom external plugins can be written that utilize the same connection methodology as the embedded plugin but can customize the parsing and routing technique on a per use-case basis.

This is a small PR and fairly straight forward, but if I missed anything please let me know.