### PR TITLE
Set Type on Tcp and Udp Input's

### DIFF
--- a/pipeline/pipeline_runner.go
+++ b/pipeline/pipeline_runner.go
@@ -215,7 +215,7 @@ func Run(config *PipelineConfig) {
 			outputsWg.Done()
 			continue
 		}
-		LogInfo.Println("Output started: ", name)
+		LogInfo.Println("Output started:", name)
 	}
 
 	for name, filter := range config.FilterRunners {
@@ -225,7 +225,7 @@ func Run(config *PipelineConfig) {
 			config.filtersWg.Done()
 			continue
 		}
-		LogInfo.Println("Filter started: ", name)
+		LogInfo.Println("Filter started:", name)
 	}
 
 	// Finish initializing the router's matchers.
@@ -260,7 +260,7 @@ func Run(config *PipelineConfig) {
 			config.inputsWg.Done()
 			continue
 		}
-		LogInfo.Printf("Input started: %s\n", name)
+		LogInfo.Println("Input started:", name)
 	}
 
 	// wait for sigint

--- a/plugins/tcp/tcp_input.go
+++ b/plugins/tcp/tcp_input.go
@@ -131,6 +131,7 @@ func (t *TcpInput) handleConnection(conn net.Conn) {
 	if !sr.UseMsgBytes() {
 		packDec := func(pack *PipelinePack) {
 			pack.Message.SetHostname(raddr)
+			pack.Message.SetType("heka.tcpinput")
 		}
 		sr.SetPackDecorator(packDec)
 	}

--- a/plugins/udp/udp_input.go
+++ b/plugins/udp/udp_input.go
@@ -106,6 +106,13 @@ func (u *UdpInput) Run(ir InputRunner, h PluginHelper) error {
 	ok := true
 	var err error
 
+	if !sr.UseMsgBytes() {
+		packDec := func(pack *PipelinePack) {
+			pack.Message.SetType("heka.udpinput")
+		}
+		sr.SetPackDecorator(packDec)
+	}
+
 	for ok {
 		select {
 		case _, ok = <-u.stopChan:

--- a/plugins/udp/udp_input_test.go
+++ b/plugins/udp/udp_input_test.go
@@ -70,6 +70,8 @@ func UdpInputSpec(c gs.Context) {
 
 		ith.MockInputRunner.EXPECT().NewSplitterRunner("").Return(ith.MockSplitterRunner)
 		ith.MockSplitterRunner.EXPECT().GetRemainingData().AnyTimes()
+		ith.MockSplitterRunner.EXPECT().UseMsgBytes().Return(false)
+		ith.MockSplitterRunner.EXPECT().SetPackDecorator(gomock.Any())
 
 		splitCall := ith.MockSplitterRunner.EXPECT().SplitStream(gomock.Any(),
 			nil).AnyTimes()


### PR DESCRIPTION
Since the Splitter code landed, the "Type" field is no longer getting set by the TcpInput and UdpInput.
If it wasn't intentional, please consider this PR to reinstate it :)
(I changed the value of the Type slightly to match what some of the others looked like - ie; lowercase, prefixed with 'heka.')

Also tweaked the formatting for the startup messages to calm my OCD.