### PR TITLE
Remove 'trim' config option.

### DIFF
--- a/docs/source/config/inputs/process.rst
+++ b/docs/source/config/inputs/process.rst
@@ -24,11 +24,12 @@ Config:
     15. A ticker_interval of 0 indicates that the command is run only once,
     and should only be used for long running processes that do not exit. If
     ticker_interval is set to 0 and the process exits, then the ProcessInput
-    will exit, invoking the restart behavior (see
-    :ref:`configuring_restarting`).
+    will exit, invoking the restart behavior (see :ref:`configuring_restarting`).
+    Ignored when used in conjunction with :ref:`config_process_directory_input`,
+    where ticker_interval value is instead parsed from the directory path.
 - immediate_start (bool):
-    If true, heka starts process immediately instead of waiting for first interval defined by ticker_interval to pass.
-    Defaults to false.
+    If true, heka starts process immediately instead of waiting for first
+    interval defined by ticker_interval to pass. Defaults to false.
 - stdout (bool):
     If true, for each run of the process chain a message will be generated
     with the last command in the chain's stdout as the payload. Defaults to
@@ -40,8 +41,6 @@ Config:
 - timeout (uint):
     Timeout in seconds before any one of the commands in the chain is
     terminated.
-- trim (bool) :
-    Trim a single trailing newline character if one exists. Default is true.
 - retries (RetryOptions, optional):
     A sub-section that specifies the settings to be used for restart behavior.
     See :ref:`configuring_restarting`
@@ -75,7 +74,6 @@ Example:
     splitter = "on_space"
     stdout = true
     stderr = false
-    trim = true
 
         [DemoProcessInput.command.0]
         bin = "/bin/cat"


### PR DESCRIPTION
Also clarify that ticker_interval is ignored when run under a ProcessDirectoryInput.