### PR TITLE
Add back CanExit plumbing

### DIFF
--- a/pipeline/plugin_runners.go
+++ b/pipeline/plugin_runners.go
@@ -711,6 +711,10 @@ func NewFORunner(name string, plugin Plugin, config CommonFOConfig,
 	}
 	runner.matcher = matcher
 
+	if config.CanExit != nil && *config.CanExit {
+		runner.canExit = true
+	}
+
 	if config.UseFraming != nil && *config.UseFraming {
 		runner.useFraming = true
 	}


### PR DESCRIPTION
A SandboxFilter dying in 0.9 causes Heka to shut down, regardless of the "can_exit" config (added in #962).
It looks like the plumbing between the config and the runner may have wandered off?  This should fix it...