### PR TITLE
Set hostname in FilePollingInput plugin

### DIFF
--- a/plugins/file/file_polling_input.go
+++ b/plugins/file/file_polling_input.go
@@ -54,6 +54,8 @@ func (input *FilePollingInput) Stop() {
 
 func (input *FilePollingInput) packDecorator(pack *pipeline.PipelinePack) {
 	pack.Message.SetType("heka.file.polling")
+	pack.Message.SetHostname(input.hostname)
+
 	field, err := message.NewField("TickerInterval", int(input.TickerInterval), "")
 	if err != nil {
 		input.runner.LogError(
@@ -76,8 +78,8 @@ func (input *FilePollingInput) Run(runner pipeline.InputRunner,
 	input.runner = runner
 	input.hostname = helper.PipelineConfig().Hostname()
 	tickChan := runner.Ticker()
-
 	sRunner := runner.NewSplitterRunner("")
+	sRunner.SetPackDecorator(input.packDecorator)
 
 	for {
 		select {

--- a/plugins/file/file_polling_input_test.go
+++ b/plugins/file/file_polling_input_test.go
@@ -80,6 +80,7 @@ func FilePollingInputSpec(c gs.Context) {
 			c.Assume(err, gs.IsNil)
 
 			ith.MockInputRunner.EXPECT().NewSplitterRunner("").Return(ith.MockSplitterRunner)
+			ith.MockSplitterRunner.EXPECT().SetPackDecorator(gomock.Any())
 			splitCall := ith.MockSplitterRunner.EXPECT().SplitStream(gomock.Any(),
 				nil).Return(io.EOF).Times(2)
 			splitCall.Do(func(f *os.File, del Deliverer) {


### PR DESCRIPTION
Looks like changes from 1b211c67108c390df907d9ae667f1c2467446238 stopped the file_polling_input from supplying the hostname in the message.  I'm happy to provide some additional tests along with this PR if desired.
