### PR TITLE
Don't set reachedEOF flag unless we're not going to return the

### DIFF
--- a/pipeline/buffered_output.go
+++ b/pipeline/buffered_output.go
@@ -256,7 +256,6 @@ func (b *BufferedOutput) streamOutput(sender BufferedOutputSender, outputError,
 						break
 					}
 				} else {
-
 					time.Sleep(time.Duration(500) * time.Millisecond)
 				}
 			} else {

--- a/pipeline/splitter_runner.go
+++ b/pipeline/splitter_runner.go
@@ -172,13 +172,13 @@ func (sr *sRunner) GetRecordFromStream(r io.Reader) (bytesRead int, record []byt
 		// We could still have one or more records at the end of the stream.
 		// Hang on to the EOF error until all the records have been used up.
 		if err == io.EOF {
-			sr.reachedEOF = true
 			if bytesRead == 0 {
 				// If we didn't read any bytes, we don't need to look for more
 				// records, we can return the EOF.
 				return bytesRead, record, err
 			}
 			// We did read some bytes, so clear the EOF for now
+			sr.reachedEOF = true
 			err = nil
 		}
 


### PR DESCRIPTION
EOF error. Fixes #1355.