### PR TITLE
Don't increment sr.readPos unless there's no error returned

### DIFF
--- a/pipeline/splitter_runner.go
+++ b/pipeline/splitter_runner.go
@@ -138,7 +138,7 @@ func (sr *sRunner) read(r io.Reader) (n int, err error) {
 	if bufCap-sr.readPos <= bufCap/2 {
 		if sr.scanPos == 0 { // Line won't fit in the current buffer.
 			newSize := bufCap * 2
-			if newSize > int(message.MAX_MESSAGE_SIZE) {
+			if newSize > int(message.MAX_RECORD_SIZE) {
 				if bufCap == int(message.MAX_RECORD_SIZE) {
 					if sr.readPos == bufCap {
 						sr.scanPos = 0
@@ -167,7 +167,6 @@ func (sr *sRunner) read(r io.Reader) (n int, err error) {
 func (sr *sRunner) GetRecordFromStream(r io.Reader) (bytesRead int, record []byte, err error) {
 	if sr.needData && !sr.reachedEOF {
 		bytesRead, err = sr.read(r)
-		sr.readPos += bytesRead
 
 		// We could still have one or more records at the end of the stream.
 		// Hang on to the EOF error until all the records have been used up.
@@ -192,6 +191,7 @@ func (sr *sRunner) GetRecordFromStream(r io.Reader) (bytesRead int, record []byt
 		}
 	}
 
+	sr.readPos += bytesRead
 	bytesRead, record = sr.splitter.FindRecord(sr.buf[sr.scanPos:sr.readPos])
 	sr.scanPos += bytesRead
 	if len(record) == 0 {

--- a/plugins/logstreamer/logstreamer_input.go
+++ b/plugins/logstreamer/logstreamer_input.go
@@ -361,7 +361,7 @@ func (lsi *LogstreamInput) deliverRecords() (err error) {
 		}
 		if len(record) > 0 {
 			if lsi.prevMsgWasTruncated == false {
-				// pack message only if previous record had normal size
+				// Send the message only if previous record had normal size.
 				if !isMessageTruncated || lsi.sRunner.KeepTruncated() {
 					lsi.sRunner.DeliverRecord(record, lsi.deliverer)
 					lsi.countRecord()


### PR DESCRIPTION
from the sr.read call. Fixes #1367.