### PR TITLE
Add configurable max message size to heka-cat

### DIFF
--- a/cmd/heka-cat/main.go
+++ b/cmd/heka-cat/main.go
@@ -51,11 +51,20 @@ func main() {
 	flagOutput := flag.String("output", "", "output filename, defaults to stdout")
 	flagTail := flag.Bool("tail", false, "don't exit on EOF")
 	flagOffset := flag.Int64("offset", 0, "starting offset for the input file in bytes")
+	flagMaxMessageSize := flag.Uint64("max-message-size", 4*1024*1024, "maximum message size in bytes")
 	flag.Parse()
 
 	if flag.NArg() != 1 {
 		flag.PrintDefaults()
 		os.Exit(1)
+	}
+
+	if *flagMaxMessageSize < uint64(4294967295) {
+		maxSize := uint32(*flagMaxMessageSize)
+		message.SetMaxMessageSize(maxSize)
+	} else {
+		fmt.Printf("Message size is too large: %d\n", flagMaxMessageSize)
+		os.Exit(8)
 	}
 
 	var err error


### PR DESCRIPTION
This lets heka-cat work with messages larger than the default 64k. A 4MB maximum is probably overkill, but it should have minimal impact as long as the actual messages encountered are small.