### PR TITLE
Dashboard: Avoid unnecessary memory allocation

### DIFF
--- a/plugins/dasher/dashboard_output.go
+++ b/plugins/dasher/dashboard_output.go
@@ -61,7 +61,6 @@ func (self *DashboardOutput) ConfigStruct() interface{} {
 		WorkingDirectory: "dashboard",
 		TickerInterval:   uint(5),
 		MessageMatcher:   "Type == 'heka.all-report' || Type == 'heka.sandbox-terminated' || Type == 'heka.sandbox-output'",
-		Headers:          make(http.Header),
 	}
 }
 


### PR DESCRIPTION
Go's `make` builtin allocates memory for a new object; a map of
HTTP headers in this case.

According to the [documentation][] for `make`, memory is allocated for map
types even if the map size is omitted:

> Map: An initial allocation is made according to the size but the
> resulting map has length 0. The size may be omitted, in which case a
> small starting size is allocated.

We can safely omit the `Headers` field entirely here and avoid
unnecessarily allocating memory.

[documentation]: http://golang.org/pkg/builtin/#make