### PR TITLE
Dashboard: Close plugin list file

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,8 @@ Bug Handling
 * Fixed SplitterRunner buffer readPos so it only increments when a read call
   doesn't return an error (#1367).
 
+* Ensured plugin list file is closed after writing to it in Dashboard plugin.
+
 0.9.0 (2015-02-25)
 ==================
 

--- a/plugins/dasher/dashboard_output.go
+++ b/plugins/dasher/dashboard_output.go
@@ -333,6 +333,7 @@ func overwritePluginListFile(dir string, sbxs map[string]*DashPluginListItem) (e
 	if file, err = os.OpenFile(filename, os.O_WRONLY|os.O_TRUNC+os.O_CREATE, 0644); err == nil {
 		enc := json.NewEncoder(file)
 		err = enc.Encode(output)
+		file.Close()
 	}
 	return
 }


### PR DESCRIPTION
Close the file once we've finished writing to it.