### PR TITLE
Added a config flag to replace all dots in stats filters

### DIFF
--- a/docs/source/config/filters/stat.rst
+++ b/docs/source/config/filters/stat.rst
@@ -27,6 +27,10 @@ Config:
     - value (string):
         Expression representing the (possibly dynamic) value that the
         `StatFilter` should emit for each received message.
+    - replace_dot (boolean):
+        Replace all dots `.` per an underscore `_` during the string
+        interpolation. It's useful if you output this result in a graphite
+        instance.
 
 - stat_accum_name (string):
     Name of a StatAccumInput instance that this StatFilter will use as its


### PR DESCRIPTION
Useful when this filter runs with graphite.
Because graphite use a dot as a namespace separator.
And so, if a Type for exmeple contains a dot, it will
mess up the graphite storage.

note: I'm a real beginner with golang. I'm sure the code could be better ;)