### PR TITLE
Honour retries regardless of ticker_interval

### DIFF
--- a/plugins/process/process_input_test.go
+++ b/plugins/process/process_input_test.go
@@ -16,7 +16,6 @@
 package process
 
 import (
-	"fmt"
 	. "github.com/mozilla-services/heka/pipeline"
 	pipeline_ts "github.com/mozilla-services/heka/pipeline/testsupport"
 	"github.com/mozilla-services/heka/pipelinemock"
@@ -159,9 +158,7 @@ func ProcessInputSpec(c gs.Context) {
 				err := pInput.Init(config)
 				c.Assume(err, gs.IsNil)
 
-				expectedErr := fmt.Errorf(
-					"BadArgs CommandChain::Wait() error: [Subcommand returned an error: [exit status 1]]")
-				ith.MockInputRunner.EXPECT().LogError(expectedErr)
+				ith.MockHelper.EXPECT().PipelineConfig().Return(pConfig)
 
 				go func() {
 					errChan <- pInput.Run(ith.MockInputRunner, ith.MockHelper)
@@ -174,7 +171,7 @@ func ProcessInputSpec(c gs.Context) {
 
 				pInput.Stop()
 				err = <-errChan
-				c.Expect(err, gs.IsNil)
+				c.Expect(err.Error(), gs.Equals, "BadArgs CommandChain::Wait() error: [Subcommand returned an error: [exit status 1]]")
 			})
 		})
 	})


### PR DESCRIPTION
I've had a crack at fixing #1412, hopefully without breaking anything else unintentionally....

It seemed like ProcessInput's ```Run()``` needed to return any kind of error from ```runOnce()``` to the plugin runner, regardless of ticker_interval.  I added a var to push into any errors that were returned, which can then be punted back up to trigger the retry behaviour.

I close the stopChan in ```runOnce()```.  I also return early in some cases.  It looked like that's what would be wanted (and reduces a little duplicate logging).  Does that seem sane?

I tried it out with good (zero-exiting), bad (non-zero exiting) and missing ProcessInput ```bin=``` commands, with ticker_interval set to both 0 and >0, and max_retries set to -1 and >=0 and it appears to do the right thing in each case.