### PR TITLE
Retry logic changes for Inputs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,9 +19,13 @@ Features
 * ProtobufEncoder now just copies the pack.MsgBytes into a new byte slice and
   returns that.
 
+* Added support for `can_exit` to inputs (defaults to false, except on
+  ProcessDirectoryInput spawned processes where it defaults to true)
+
 Bug Handling
 ------------
 
+* More ProcessInput/ProcessDirectoryInput retry logic fixes (#1412 & #1418)
 
 0.9.1 (2015-??-??)
 ==================

--- a/docs/source/config/index.rst
+++ b/docs/source/config/index.rst
@@ -252,10 +252,13 @@ Example:
 Configuring Restarting Behavior
 ===============================
 
-Plugins that support being restarted have a set of options that govern how the
-restart is handled. If preferred, the plugin can be configured to not restart
-at which point hekad will exit, or it could be restarted only 100 times, or
-restart attempts can proceed forever.
+Plugins that support being restarted have a set of options that govern how a
+restart is handled if they exit with an error.  If preferred, the plugin can be
+configured to not restart, or it could be restarted only 100 times, or restart
+attempts can proceed forever.
+Once the `max_retries` have been exceeded the plugin will be unregistered,
+potentially triggering hekad to shutdown (depending on the plugin's `can_exit`
+configuration).
 
 Adding the restarting configuration is done by adding a config section to a
 plugin's configuration called `retries`. A small amount of jitter will be

--- a/docs/source/config/inputs/index.rst
+++ b/docs/source/config/inputs/index.rst
@@ -35,6 +35,10 @@ initialization code.
 	logging an error message, decode failure will cause the original,
 	undecoded message to be tagged with a `decode_failure` field (set to true)
 	and delivered to the router for possible further processing.
+- can_exit (bool, optional):
+        If false, the input plugin exiting will trigger a Heka shutdown.  If
+        set to true, Heka will continue processing other plugins.  Defaults to
+        false on most inputs.
 - splitter (string, optional)
 	Splitter to be used by the input. This should refer to the name of a
 	registered splitter plugin configuration. It specifies how the input

--- a/docs/source/config/inputs/process.rst
+++ b/docs/source/config/inputs/process.rst
@@ -26,7 +26,7 @@ Config:
     ticker_interval is set to 0 and the process exits, then the ProcessInput
     will exit, invoking the restart behavior (see :ref:`configuring_restarting`).
     Ignored when used in conjunction with :ref:`config_process_directory_input`,
-    where ticker_interval value is instead parsed from the directory path.
+    where `ticker_interval` value is instead parsed from the directory path.
 - immediate_start (bool):
     If true, heka starts process immediately instead of waiting for first
     interval defined by ticker_interval to pass. Defaults to false.

--- a/docs/source/config/inputs/processdir.rst
+++ b/docs/source/config/inputs/processdir.rst
@@ -36,10 +36,10 @@ For example, a process_dir might look like this::
 This indicates one process to be run every five seconds, two processes to be
 run every 61 seconds, and one process to be run every 302 seconds.
 
-Note that ProcessDirectory will ignore any files that are not nested one level
-deep, are not in a folder named for an integer 0 or greater, and do not end
-with '.toml'. Each file which meets these criteria, such as those shown in the
-example above, should contain the TOML configuration for exactly one
+Note that ProcessDirectoryInput will ignore any files that are not nested one
+level deep, are not in a folder named for an integer 0 or greater, and do not
+end with '.toml'. Each file which meets these criteria, such as those shown in
+the example above, should contain the TOML configuration for exactly one
 :ref:`config_process_input`, matching that of a standalone ProcessInput with
 the following restrictions:
 
@@ -49,8 +49,11 @@ the following restrictions:
 - Any specified `ticker_interval` value will be *ignored*. The ticker interval
   value to use will be parsed from the directory path.
 
-If the specified process fails to run or the ProcessInput config fails for any
-other reason, ProcessDirectoryInput will log an error message and continue.
+By default, if the specified process fails to run or the ProcessInput config
+fails for any other reason, ProcessDirectoryInput will log an error message and
+continue, as if the ProcessInput's `can_exit` flag has been set to true.
+If the managed ProcessInput's `can_exit` flag is manually set to `false`, it
+will trigger a Heka shutdown.
 
 Config:
 
@@ -58,12 +61,14 @@ Config:
     Amount of time, in seconds, between scans of the process_dir. Defaults to
     300 (i.e. 5 minutes).
 - process_dir (string, optional):
-	This is the root folder of the tree where the scheduled jobs are defined.
-	Absolute paths will be honored, relative paths will be computed relative
-	to Heka's globally specified share_dir. Defaults to "processes" (i.e.
-	"$share_dir/processes").
+    This is the root folder of the tree where the scheduled jobs are defined.
+    Absolute paths will be honored, relative paths will be computed relative to
+    Heka's globally specified share_dir. Defaults to "processes" (i.e.
+    "$share_dir/processes").
 - retries (RetryOptions, optional):
-    A sub-section that specifies the settings to be used for restart behavior.
+    A sub-section that specifies the settings to be used for restart behavior
+    of the ProcessDirectoryInput (not the individual ProcessInputs, which are
+    configured independently).
     See :ref:`configuring_restarting`
 
 Example:

--- a/docs/source/developing/plugin.rst
+++ b/docs/source/developing/plugin.rst
@@ -147,19 +147,16 @@ generally route messages to specific outputs using the
 Restarting Plugins
 ==================
 
-In the event that your plugin fails to initialize properly at startup, hekad
-will exit. However, once hekad is running, if the plugin should fail (perhaps
-because a network connection dropped, a file became unavailable, etc) then the
-plugin will exit. If the plugin supports being restarted then Heka will
-attempt to reset, reinitialize, and restart the plugin. If this fails, Heka
-will try again up until the specified max_retries value. If the failure
-continues beyond the maximum number of retries, or if the plugin didn't
-support restarting in the first place, then Heka will either shut down or, if
-the plugin is a filter or an output with the ``can_exit`` setting set to true,
-the plugin will be removed from operation and Heka will continue to run.
+If your plugin supports being restarted and either fails to initialize properly
+at startup, or fails during Run with an error (perhaps because a network
+connection dropped, a file became unavailable, etc) then Heka will attempt to
+reinitialize and restart it up until the specified max_retries value.
 
-If the reinitialization and restarting is successful, then the retry count
-will be reset to zero and everything will continue to function as normal.
+If the failure continues beyond the maximum number of retries, or if the plugin
+didn't support restarting in the first place, then Heka will either shut down
+or, if the plugin is an input, filter or an output with the ``can_exit``
+setting set to true, the plugin will be removed from operation and Heka will
+continue to run.
 
 To add restart support to your plugin, you must implement the ``Restarting``
 interface defined in the `config.go <https://github.com/mozilla-

--- a/pipeline/config.go
+++ b/pipeline/config.go
@@ -522,6 +522,7 @@ type CommonInputConfig struct {
 	Splitter           string
 	SyncDecode         *bool `toml:"synchronous_decode"`
 	SendDecodeFailures *bool `toml:"send_decode_failures"`
+	CanExit            *bool `toml:"can_exit"`
 	Retries            RetryOptions
 }
 
@@ -881,8 +882,12 @@ func (m *pluginMaker) makeInputRunner(name string, input Input, defaultTick uint
 		}
 	}
 	if commonInput.SendDecodeFailures == nil {
-		commonInput.SendDecodeFailures, err = m.getDefaultBool("SendDecodeFailures")
-		if err != nil {
+		if commonInput.SendDecodeFailures, err = m.getDefaultBool("SendDecodeFailures"); err != nil {
+			return nil, err
+		}
+	}
+	if commonInput.CanExit == nil {
+		if commonInput.CanExit, err = m.getDefaultBool("CanExit"); err != nil {
 			return nil, err
 		}
 	}

--- a/pipeline/plugin_runners.go
+++ b/pipeline/plugin_runners.go
@@ -192,6 +192,7 @@ type iRunner struct {
 	syncDecode         bool
 	sendDecodeFailures bool
 	deliver            DeliverFunc
+	canExit            bool
 	shutdownWanters    []WantsDecoderRunnerShutdown
 	shutdownLock       sync.Mutex
 }
@@ -206,6 +207,10 @@ func (ir *iRunner) Transient() bool {
 
 func (ir *iRunner) SetTransient(transient bool) {
 	ir.transient = transient
+}
+
+func (ir *iRunner) IsStoppable() bool {
+	return ir.canExit
 }
 
 // Creates and returns a new (not yet started) InputRunner associated w/ the
@@ -227,6 +232,10 @@ func NewInputRunner(name string, input Input, config CommonInputConfig) (ir Inpu
 	if config.SendDecodeFailures != nil {
 		runner.sendDecodeFailures = *config.SendDecodeFailures
 	}
+	if config.CanExit != nil && *config.CanExit {
+		runner.canExit = true
+	}
+
 	return runner
 }
 
@@ -279,59 +288,77 @@ func (ir *iRunner) Starter(h PluginHelper, wg *sync.WaitGroup) {
 	}
 
 	for !globals.IsShuttingDown() {
+
 		// ir.Input().Run() shouldn't return unless error or shutdown.
 		err := ir.input.Run(ir, h)
-		if err != nil {
-			ir.LogError(err)
-		} else if !ir.transient {
-			rh.Reset()
-			ir.LogMessage("stopped")
-		}
+		registered, ok := ir.pConfig.InputRunners[ir.name]
 
-		// Send shutdown signal to any decoders that need it.
-		if len(ir.shutdownWanters) > 0 {
-			ir.shutdownLock.Lock()
-			for _, wanter := range ir.shutdownWanters {
-				wanter.Shutdown()
+		if !ok || registered != ir || globals.IsShuttingDown() {
+			// Plugin was removed deliberately from the list of InputRunners or
+			// has been superseded by another instance, or we're in shutdown.
+			// In this case, avoid triggering a Heka shutdown ourselves.
+			ir.Unregister(ir.pConfig)
+			return
+		} else if err == nil {
+			// Plugin exited cleanly.
+			break
+		} else {
+			// Plugin exited by returning an error.
+			ir.LogError(err)
+
+			// If we don't support restart, just stop here.
+			recon, ok := ir.plugin.(Restarting)
+			if !ok {
+				break
 			}
-			ir.shutdownLock.Unlock()
-		}
 
-		// Are we supposed to stop? Save ourselves some time by exiting now.
-		if globals.IsShuttingDown() {
-			break
-		}
+			// Otherwise we'll execute the Retry config
+			recon.CleanupForRestart()
+			if ir.maker == nil {
+				ir.maker = ir.pConfig.makers["Input"][ir.name]
+			}
 
-		// If we're transient we just exit.
-		if ir.transient {
-			break
-		}
-		// We're not transient, we either try to restart or we shut down
-		// altogether.
-		recon, ok := ir.plugin.(Restarting)
-		if !ok {
-			ir.LogMessage("has stopped, shutting down.")
-			globals.ShutDown()
-			break
-		}
+		initLoop:
+			if err = rh.Wait(); err != nil {
+				// We've used up our retry attempts, exit.
+				ir.LogError(err)
+				break
+			}
+			ir.LogMessage(fmt.Sprintf("Restarting (attempt %d/%d)\n",
+				rh.times, rh.retries))
 
-		recon.CleanupForRestart()
-		if ir.maker == nil {
-			ir.maker = ir.pConfig.makers["Input"][ir.name]
-		}
-	initLoop:
-		if err = rh.Wait(); err != nil {
-			// We've used up our retry attempts, exit.
-			ir.LogError(err)
-			globals.ShutDown()
-			break
-		}
-		ir.LogMessage("exited, now restarting.")
-		if err = ir.plugin.Init(ir.maker.Config()); err != nil {
-			ir.LogError(err)
-			goto initLoop
+			// If we've not been created elsewhere, call the plugin's Init()
+			if !ir.transient {
+				if err = ir.plugin.Init(ir.maker.Config()); err != nil {
+					// We couldn't reInit the plugin, do a mini-retry loop
+					ir.LogError(err)
+					goto initLoop
+				}
+			}
+
 		}
 	}
+
+	ir.Unregister(ir.pConfig)
+
+	// If we're not a stoppable input, trigger Heka shutdown.
+	if !ir.IsStoppable() {
+		globals.ShutDown()
+	}
+}
+
+func (ir *iRunner) Unregister(pConfig *PipelineConfig) error {
+
+	// Send shutdown signal to any decoders that need it.
+	if len(ir.shutdownWanters) > 0 {
+		ir.shutdownLock.Lock()
+		for _, wanter := range ir.shutdownWanters {
+			wanter.Shutdown()
+		}
+		ir.shutdownLock.Unlock()
+	}
+
+	return nil
 }
 
 func (ir *iRunner) Inject(pack *PipelinePack) {

--- a/pipeline/plugin_runners_test.go
+++ b/pipeline/plugin_runners_test.go
@@ -39,6 +39,7 @@ func (s *StoppingInput) Init(config interface{}) (err error) {
 }
 
 func (s *StoppingInput) Run(ir InputRunner, h PluginHelper) (err error) {
+	err = errors.New("Unclean Exit")
 	return
 }
 
@@ -88,6 +89,7 @@ func InputRunnerSpec(c gs.Context) {
 		var wg sync.WaitGroup
 
 		startRunner := func(runner InputRunner) {
+			pConfig.InputRunners[runner.Name()] = runner
 			wg.Add(1)
 			err := runner.Start(mockHelper, &wg)
 			if err != nil {

--- a/plugins/process/process_chain.go
+++ b/plugins/process/process_chain.go
@@ -110,7 +110,7 @@ func (mc *ManagedCmd) kill() (err error) {
 	}
 	// killing process will make Wait() return
 	<-mc.done
-	return fmt.Errorf("subprocess was killed: [%s %s]", mc.Path, strings.Join(mc.Args, " "))
+	return fmt.Errorf("subprocess was killed: [%s]", strings.Join(mc.Args, " "))
 }
 
 // This resets a command so that we can run the command again. Usually so that
@@ -184,8 +184,7 @@ func (cc *CommandChain) Start() (err error) {
 		}
 
 		if err != nil {
-			return fmt.Errorf("Command [%s %s] triggered an error: [%s]",
-				cmd.Path,
+			return fmt.Errorf("Command [%s] triggered an error: [%s]",
 				strings.Join(cmd.Args, " "),
 				err.Error())
 		}

--- a/plugins/process/process_input_test.go
+++ b/plugins/process/process_input_test.go
@@ -16,7 +16,6 @@
 package process
 
 import (
-	"fmt"
 	. "github.com/mozilla-services/heka/pipeline"
 	pipeline_ts "github.com/mozilla-services/heka/pipeline/testsupport"
 	"github.com/mozilla-services/heka/pipelinemock"
@@ -159,10 +158,6 @@ func ProcessInputSpec(c gs.Context) {
 				err := pInput.Init(config)
 				c.Assume(err, gs.IsNil)
 
-				expectedErr := fmt.Errorf(
-					"BadArgs CommandChain::Wait() error: [Subcommand returned an error: [exit status 1]]")
-				ith.MockInputRunner.EXPECT().LogError(expectedErr)
-
 				go func() {
 					errChan <- pInput.Run(ith.MockInputRunner, ith.MockHelper)
 				}()
@@ -174,7 +169,7 @@ func ProcessInputSpec(c gs.Context) {
 
 				pInput.Stop()
 				err = <-errChan
-				c.Expect(err, gs.IsNil)
+				c.Expect(err.Error(), gs.Equals, "CommandChain::Wait() error: [Subcommand returned an error: [exit status 1]]")
 			})
 		})
 	})


### PR DESCRIPTION
* Honour retry config regardless of ticker_interval, or whether spawned from a
  ProcessDirectoryInput (for #1412 and #1418)
* Plugins exiting cleanly will not be subject to Retries
* Make InputRunners support can_exit (defaults to false, ProcessDirectoryInput
  spawned processes default to true).  Skipped if runner was removed
  deliberately (ie; on a ProcessDirectoryInput config change)
* ProcessInput spawned commands pass exit error back up to plugin_runner.
* Reset the stopChan, once mutex, exitError and cc in Run rather than Init (so
  ProcessDirectoryInput commands spawned after a config change have a fresh
  start)
* Doc + some test updates (could do with more improvement)