### PR TITLE
Raw syslog datagrams multidecoder example

### DIFF
--- a/examples/raw_syslog_unixgram.toml
+++ b/examples/raw_syslog_unixgram.toml
@@ -1,0 +1,44 @@
+[syslog_udp]
+type = "UdpInput"
+net = "unixgram"
+address = "/dev/log"
+decoder = "RawSyslogDecoder"
+
+[RawSyslogDecoder]
+type = "MultiDecoder"
+subs = ['SyslogDecoderWProcess', 'SyslogDecoderSimple']
+cascade_strategy = "first-wins"
+## some extra verbosity here when matching the simple decoder (as the first fails with error)
+log_sub_errors = true
+
+[SyslogDecoderWProcess]
+type = "PayloadRegexDecoder"
+## <86>Mar 27 11:18:23 su[975952]: pam_unix(su:session): session opened for user root by (uid=0)
+match_regex = '^<(?P<Pri>\d+)>(?P<Timestamp>[A-Za-z]{3} \d{2} \d+:\d+:\d+) (?P<Payload>((?P<ProcessName>[^\[:]+)\[(?P<Pid>\d+)\]: )?.+)$'
+timestamp_layout = "Jan 02 15:04:05"
+# timestamp_location = "Europe/Amsterdam" ## specify here the timezone, as timestamps are provided in local time
+
+[SyslogDecoderWProcess.message_fields]
+Pid = "%Pid%"
+Payload = "%Payload%"
+ProcessName = "%ProcessName%"
+## see http://en.wikipedia.org/wiki/Syslog#Severity_levels for properly decoding the PRI field
+Pri = "%Pri%"
+
+[SyslogDecoderSimple]
+type = "PayloadRegexDecoder"
+## <86>Mar 27 11:18:23 root: hello
+match_regex = '(^|\n)<(?P<Pri>\d+)>(?P<Timestamp>[A-Za-z]{3} \d{2} \d+:\d+:\d+) (?P<Payload>[^\n]+)'
+timestamp_layout = "Jan 02 15:04:05"
+# timestamp_location = "Europe/Amsterdam" ## specify here the timezone, as timestamps are provided in local time
+
+[SyslogDecoderSimple.message_fields]
+Payload = "%Payload%"
+Pri = "%Pri%"
+
+[RstEncoder]
+## provides simple debugging output
+
+[LogOutput]
+message_matcher = "TRUE"
+encoder = "RstEncoder"


### PR DESCRIPTION
I am proposing to add an example to cover #1162 and the older #790.

This is particularly interesting in the case of containers, if one does not want to run syslog/rsyslog inside the container but rather directly read ``/dev/log`` via heka.

Although the best scenario is to let syslog/rsyslog poll ``/dev/log`` and write their own log (which is then feeded to/read by heka), I prefer this approach and I provide here a working example (tested with 0.9.0) that should also allow people to easily extend/build on.

I am new to heka, so please tell me about possible improvements. Feedback for PR changes welcome as well :)

**NOTE:** might require some refactoring of the name of sibling example.toml, if this is accepted at all

1. Is there already a decoder that does this?
2. If not, would this better be converted to a LUA decoder?

I didn't write (2) as I wanted a simple message proxying feature, but for official inclusion it might be a valid option instead of a multidecoder example (also to properly parse PRI).