### PR TITLE
Check for decoder existence when decoder is specified, check

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,11 @@ Bug Handling
 
 * Fix a gziped file seeking in logstreamer may cause an OOM exception.
 
+* Always check for decoder existence when a decoder is specified for an input
+  plugin (#1439).
+
+* Check `IsStoppable()` on all input, filter, output plugins if they error at
+  startup time, only shut down Heka if false.
 
 0.9.1 (2015-03-13)
 ==================

--- a/pipeline/pipeline_runner.go
+++ b/pipeline/pipeline_runner.go
@@ -213,6 +213,9 @@ func Run(config *PipelineConfig) {
 		if err = output.Start(config, &outputsWg); err != nil {
 			LogError.Printf("Output '%s' failed to start: %s", name, err)
 			outputsWg.Done()
+			if !output.IsStoppable() {
+				globals.ShutDown()
+			}
 			continue
 		}
 		LogInfo.Println("Output started:", name)
@@ -223,6 +226,9 @@ func Run(config *PipelineConfig) {
 		if err = filter.Start(config, &config.filtersWg); err != nil {
 			LogError.Printf("Filter '%s' failed to start: %s", name, err)
 			config.filtersWg.Done()
+			if !filter.IsStoppable() {
+				globals.ShutDown()
+			}
 			continue
 		}
 		LogInfo.Println("Filter started:", name)
@@ -258,6 +264,9 @@ func Run(config *PipelineConfig) {
 		if err = input.Start(config, &config.inputsWg); err != nil {
 			LogError.Printf("Input '%s' failed to start: %s", name, err)
 			config.inputsWg.Done()
+			if !input.IsStoppable() {
+				globals.ShutDown()
+			}
 			continue
 		}
 		LogInfo.Println("Input started:", name)

--- a/pipeline/plugin_runners.go
+++ b/pipeline/plugin_runners.go
@@ -263,6 +263,12 @@ func (ir *iRunner) Start(h PluginHelper, wg *sync.WaitGroup) (err error) {
 			ir.config.Splitter, err.Error())
 	}
 
+	if ir.config.Decoder != "" {
+		_, ok := ir.pConfig.Decoder(ir.config.Decoder)
+		if !ok {
+			return fmt.Errorf("no registered '%s' decoder", ir.config.Decoder)
+		}
+	}
 	go ir.Starter(h, wg)
 	return
 }
@@ -274,7 +280,9 @@ func (ir *iRunner) Starter(h PluginHelper, wg *sync.WaitGroup) {
 	rh, err := NewRetryHelper(ir.config.Retries)
 	if err != nil {
 		ir.LogError(err)
-		globals.ShutDown()
+		if !ir.IsStoppable() {
+			globals.ShutDown()
+		}
 		return
 	}
 
@@ -858,7 +866,9 @@ func (foRunner *foRunner) Starter(helper PluginHelper, wg *sync.WaitGroup) {
 	rh, err := NewRetryHelper(foRunner.config.Retries)
 	if err != nil {
 		foRunner.LogError(err)
-		globals.ShutDown()
+		if !foRunner.IsStoppable() {
+			globals.ShutDown()
+		}
 		return
 	}
 


### PR DESCRIPTION
for IsStoppable on all input, filter, output plugins to decide
whether startup failure should cause Heka to exit. Fixes #1439.