### PR TITLE
ElasticSearch bulk api expects newline in the end of the payload

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@
 Bug Handling
 ------------
 
+* ElasticSearch payload encoder will ensure there is a newline in the
+  end of the payload in order for the bulk API to work correctly (#1457).
+
 * Fix a gziped file seeking in logstreamer may cause an OOM exception.
 
 * Always check for decoder existence when a decoder is specified for an input

--- a/sandbox/lua/encoders/es_payload.lua
+++ b/sandbox/lua/encoders/es_payload.lua
@@ -78,7 +78,7 @@ function process_message()
 
     -- bulk api expects newline in the end of the payload
     if not string.match(payload, "\n$") then
-	      payload = payload .. "\n"
+        add_to_payload("\n")
     end
 
     add_to_payload(idx_json, "\n", payload)

--- a/sandbox/lua/encoders/es_payload.lua
+++ b/sandbox/lua/encoders/es_payload.lua
@@ -72,8 +72,16 @@ function process_message()
     if ts_from_message then
         ns = read_message("Timestamp")
     end
+
     local idx_json = elasticsearch.bulkapi_index_json(index, type_name, id, ns)
-    add_to_payload(idx_json, "\n", read_message("Payload"))
+    local payload  = read_message("Payload")
+
+    -- bulk api expects newline in the end of the payload
+    if not string.match(payload, "\n$") then
+	      payload = payload .. "\n"
+    end
+
+    add_to_payload(idx_json, "\n", payload)
     inject_payload()
     return 0
 end


### PR DESCRIPTION
Below is the tcpflow output without the newline:

```
POST /_bulk HTTP/1.1
Host: 172.17.0.36:9200
User-Agent: Go 1.1 package http
Content-Length: 97
Accept: application/json
Accept-Encoding: gzip
 
{"index":{"_index":"2015.03.31","_type":"7d98073d388e"}}
{"bar":"boo","log":"awesome"}
HTTP/1.1 400 Bad Request
Content-Type: application/json; charset=UTF-8
Content-Length: 99
 
{"error":"ActionRequestValidationException[Validation Failed: 1: no requests added;]","status":400}
```