### PR TITLE
ticker_interval in Stat Accumulator Input be greater than 0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -47,6 +47,9 @@ Bug Handling
 * ProcessInput fixed to no longer leak decoder goroutines when reconfigured
   via ProcessDirectoryInput-driven config changes (#1444).
 
+* Check configuration, ticker_interval in Stat Accumulator Input be greater 
+  than 0 (#1474).
+
 0.9.2 (2015-??-??)
 ==================
 

--- a/pipeline/plugin_runners_test.go
+++ b/pipeline/plugin_runners_test.go
@@ -116,6 +116,7 @@ func InputRunnerSpec(c gs.Context) {
 			}
 			iConfig := &StatAccumInputConfig{
 				EmitInPayload: true,
+				TickerInterval: 10,
 			}
 			err := input.Init(iConfig)
 			c.Assume(err, gs.IsNil)

--- a/pipeline/stat_accum_input.go
+++ b/pipeline/stat_accum_input.go
@@ -125,6 +125,11 @@ func (sm *StatAccumInput) Init(config interface{}) error {
 	sm.stopChan = make(chan bool, 1)
 
 	sm.config = config.(*StatAccumInputConfig)
+	if sm.config.TickerInterval == 0{
+		return errors.New(
+			"TickerInterval must be greater than 0.",
+		)
+	}
 	if !sm.config.EmitInPayload && !sm.config.EmitInFields {
 		return errors.New(
 			"One of either `EmitInPayload` or `EmitInFields` must be set to true.",

--- a/pipeline/stat_accum_input_test.go
+++ b/pipeline/stat_accum_input_test.go
@@ -48,6 +48,14 @@ func StatAccumInputSpec(c gs.Context) {
 		pConfig := NewPipelineConfig(nil)
 		statAccumInput.pConfig = pConfig
 
+		c.Specify("ticker interval is zero", func() {
+			config.TickerInterval = 0
+			err := statAccumInput.Init(config)
+			c.Expect(err, gs.Not(gs.IsNil))
+			expected := "TickerInterval must be greater than 0."
+			c.Expect(err.Error(), gs.Equals, expected)
+		})
+
 		c.Specify("validates that data is emitted", func() {
 			config.EmitInPayload = false
 			err := statAccumInput.Init(config)


### PR DESCRIPTION
I suppose ticker_interval in Stat Accumulator Input should be greater than 0.
Mistakenly setting this value to 0 would break the Accumulator, and possibly divided by 0 error.
This pull requests resolves #1474.