### PR TITLE
Make sure we actually use the result of the FilterOld call. Fixes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@
 Bug Handling
 ------------
 
+* Fixed bug where LogstreamerInput wasn't honoring `oldest_duration` setting
+  (#1437).
+
 * ElasticSearch payload encoder will ensure there is a newline in the
   end of the payload in order for the bulk API to work correctly (#1457).
 

--- a/logstreamer/filehandling.go
+++ b/logstreamer/filehandling.go
@@ -4,7 +4,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 # The Initial Developer of the Original Code is the Mozilla Foundation.
-# Portions created by the Initial Developer are Copyright (C) 2014
+# Portions created by the Initial Developer are Copyright (C) 2014-2015
 # the Initial Developer. All Rights Reserved.
 #
 # Contributor(s):
@@ -447,7 +447,7 @@ func (ls *LogstreamSet) ScanForLogstreams() (result []string, errors *MultipleEr
 
 	// Filter out old logfiles
 	if ls.oldestDuration != time.Duration(0) {
-		logfiles.FilterOld(time.Now().Add(-ls.oldestDuration))
+		logfiles = logfiles.FilterOld(time.Now().Add(-ls.oldestDuration))
 	}
 
 	// Setup all the sorting ints in every logfile


### PR DESCRIPTION
#1437.