### PR TITLE
ElasticSearchOutput now correctly recovers from and shuts

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@
 Bug Handling
 ------------
 
+* Fixed ElasticSearch recovery after full queue when `queue_full_action` is
+  set to "drop" or "block".
+
 * Fixed TcpOutput recovery after full queue when `queue_full_action` is set to
   "drop" or "block" (#1484).
 


### PR DESCRIPTION
down during queue full situations.