### PR TITLE
Check for out of bound index on truncated lines.

### DIFF
--- a/plugins/statsd/statsd_input.go
+++ b/plugins/statsd/statsd_input.go
@@ -166,7 +166,7 @@ func parseMessage(message []byte) ([]Stat, [][]byte) {
 		}
 
 		pipePos := bytes.IndexByte(line[colonPos+1:], '|') + colonPos + 1
-		if pipePos == -1 || len(line) < pipePos+2 {
+		if pipePos == -1 || pipePos == colonPos || len(line) < pipePos+2 {
 			badLines = append(badLines, line)
 			continue
 		}


### PR DESCRIPTION
pipePos and colonPos can end up being the same when
encountering a truncated line, but this isn't caught which causes hekad
to crash.
This adds a check for that condition which will simply skip the line
instead of crashing.