### PR TITLE
Using stftime literals for filenames during rotation in FileOutput plugin (#1469)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,8 @@ Backwards Incompatibilities
 
 * Removed unused PipelinePack.Decoded attribute.
 
+* Using stftime literals for filenames during rotation in FileOutput plugin (#1469).
+
 Features
 --------
 

--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -153,6 +153,7 @@ git_clone(https://github.com/rafrombrc/gospec 2e46585948f47047b0c217d00fa24bbc4e
 git_clone(https://github.com/crankycoder/g2s 2594f7a035ed881bb10618bc5dc4440ef35c6a29)
 git_clone(https://github.com/crankycoder/xmlpath 670b185b686fd11aa115291fb2f6dc3ed7ebb488)
 git_clone(https://github.com/thoj/go-ircevent 90dc7f966b95d133f1c65531c6959b52effd5e40)
+git_clone(https://github.com/jehiah/go-strftime 834e15c05a45371503440cc195bbd05c9a0968d9)
 
 hg_clone(https://code.google.com/p/snappy-go default)
 git_clone(https://github.com/Shopify/sarama ab8518c05fd3775bdbf06c97d97389fe8af2dfef)

--- a/docs/source/config/outputs/file.rst
+++ b/docs/source/config/outputs/file.rst
@@ -11,8 +11,8 @@ Config:
 
 - path (string):
     Full path to the output file. If date rotation is in use, then the output
-    file path can support Go's time.Format syntax to embed timestamps in the
-    file path: http://golang.org/pkg/time/#Time.Format
+    file path can support strftime syntax to embed timestamps in the
+    file path: http://strftime.org
 - perm (string, optional):
     File permission for writing. A string of the octal digit representation.
     Defaults to "644".


### PR DESCRIPTION
@rafrombrc @trink could you look at this? Test passes, but second pair of critical eyes will be appreciated (as always).