### PR TITLE
Invalidate MsgBytes if the SandboxDecoder copies headers from

### DIFF
--- a/pipeline/splitter_runner.go
+++ b/pipeline/splitter_runner.go
@@ -263,6 +263,7 @@ func (sr *sRunner) DeliverRecord(record []byte, del Deliverer) {
 	// Give the input one last chance to mutate the pack.
 	if sr.packDecorator != nil {
 		sr.packDecorator(pack)
+		pack.TrustMsgBytes = false
 	}
 	if del == nil {
 		sr.ir.Deliver(pack)

--- a/sandbox/plugins/sandbox_decoder.go
+++ b/sandbox/plugins/sandbox_decoder.go
@@ -218,24 +218,31 @@ func (s *SandboxDecoder) SetDecoderRunner(dr pipeline.DecoderRunner) {
 			// from the original message.
 			if s.pack.Message.Uuid == nil {
 				s.pack.Message.SetUuid(uuid.NewRandom()) // UUID should always be unique
+				s.pack.TrustMsgBytes = false
 			}
 			if s.pack.Message.Timestamp == nil {
 				s.pack.Message.SetTimestamp(original.GetTimestamp())
+				s.pack.TrustMsgBytes = false
 			}
 			if s.pack.Message.Type == nil {
 				s.pack.Message.SetType(original.GetType())
+				s.pack.TrustMsgBytes = false
 			}
 			if s.pack.Message.Hostname == nil {
 				s.pack.Message.SetHostname(original.GetHostname())
+				s.pack.TrustMsgBytes = false
 			}
 			if s.pack.Message.Logger == nil {
 				s.pack.Message.SetLogger(original.GetLogger())
+				s.pack.TrustMsgBytes = false
 			}
 			if s.pack.Message.Severity == nil {
 				s.pack.Message.SetSeverity(original.GetSeverity())
+				s.pack.TrustMsgBytes = false
 			}
 			if s.pack.Message.Pid == nil {
 				s.pack.Message.SetPid(original.GetPid())
+				s.pack.TrustMsgBytes = false
 			}
 		}
 		s.packs = append(s.packs, s.pack)

--- a/sandbox/plugins/sandbox_decoders_test.go
+++ b/sandbox/plugins/sandbox_decoders_test.go
@@ -89,6 +89,19 @@ func DecoderSpec(c gs.Context) {
 				err = os.Remove("sandbox_preservation/serialize.data")
 				c.Expect(err, gs.IsNil)
 			})
+
+			c.Specify("Propagates headers and invalidates MsgBytes when doing so", func() {
+				data := "1376389920 debug id=2321 url=example.com item=1"
+				decoder.SetDecoderRunner(dRunner)
+				pack.Message.SetPayload(data)
+				logger := "Test Logger Value"
+				pack.Message.SetLogger(logger)
+				_, err = decoder.Decode(pack)
+				c.Assume(err, gs.IsNil)
+
+				c.Expect(pack.Message.GetLogger(), gs.Equals, logger)
+				c.Expect(pack.TrustMsgBytes, gs.IsFalse)
+			})
 		})
 
 		c.Specify("that only uses write_message", func() {


### PR DESCRIPTION
original message after deserializing from protobuf.