### PR TITLE
#1522, ProcessInput deadlock when subcommand returns non-0.

### DIFF
--- a/plugins/process/process_input.go
+++ b/plugins/process/process_input.go
@@ -287,6 +287,7 @@ func (pi *ProcessInput) RunCmd() {
 			pi.cc = pi.cc.clone()
 			pi.runOnce()
 			if pi.exitError != nil {
+				pi.stopChan <- true
 				return
 			}
 		case <-pi.stopChan:


### PR DESCRIPTION
ProcessInput deadlock when subcommand returns non-0

Instead of return, input should send true to stopChan:
process_input.go line 290
if pi.exitError != nil {
pi.stopChan <- true
return
}
Will send a pull request.