### PR TITLE
Use lock and clean up decoder list during pipeline shutdown,

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,9 @@ Bug Handling
 * Removed state from PluginMaker to remove race conditions during plugin
   construction (#1532).
 
+* Get decoder lock before cleaning up decoders during pipeline shutdown to
+  avoid race condition panics during exit (#1531).
+
 0.9.2 (2015-04-22)
 ==================
 

--- a/pipeline/pipeline_runner.go
+++ b/pipeline/pipeline_runner.go
@@ -4,7 +4,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 # The Initial Developer of the Original Code is the Mozilla Foundation.
-# Portions created by the Initial Developer are Copyright (C) 2012-2014
+# Portions created by the Initial Developer are Copyright (C) 2012-2015
 # the Initial Developer. All Rights Reserved.
 #
 # Contributor(s):
@@ -17,8 +17,6 @@
 package pipeline
 
 import (
-	"github.com/mozilla-services/heka/message"
-	"github.com/rafrombrc/go-notify"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -27,6 +25,9 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	"github.com/mozilla-services/heka/message"
+	notify "github.com/rafrombrc/go-notify"
 )
 
 const (
@@ -302,11 +303,14 @@ func Run(config *PipelineConfig) {
 	config.inputsLock.Unlock()
 	config.inputsWg.Wait()
 
+	config.allDecodersLock.Lock()
 	LogInfo.Println("Waiting for decoders shutdown")
 	for _, decoder := range config.allDecoders {
 		close(decoder.InChan())
-		LogError.Printf("Stop message sent to decoder '%s'", decoder.Name())
+		LogInfo.Printf("Stop message sent to decoder '%s'", decoder.Name())
 	}
+	config.allDecoders = config.allDecoders[:0]
+	config.allDecodersLock.Unlock()
 	config.decodersWg.Wait()
 	LogInfo.Println("Decoders shutdown complete")
 

--- a/pipeline/plugin_maker.go
+++ b/pipeline/plugin_maker.go
@@ -317,7 +317,6 @@ func (m *pluginMaker) makeSplitterRunner(name string, config interface{}, splitt
 func (m *pluginMaker) makeInputRunner(name string, config interface{}, input Input,
 	defaultTick uint) (InputRunner, error) {
 
-	fmt.Println("Before fetching")
 	commonConfig, err := m.prepCommonTypedConfig()
 	if err != nil {
 		return nil, fmt.Errorf("Can't prep common typed config: %s", err.Error())


### PR DESCRIPTION
remove debug output, send "stopping decoder" output to stdout
instead of stderr. Fixes #1531.