### PR TITLE
Allow to overwrite the ContainerName using a Container Environment Variable. Issue 1545

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -57,6 +57,8 @@ Features
 
 * Added `graphite` module with helpers allowing to generate graphite metrics for counters and timeseries (#1461).
 
+* Allow to overwrite ContainerName using a Container environment variable for the DockerLogInput. (#1545)
+
 Bug Handling
 ------------
 

--- a/docs/source/config/inputs/docker_log.rst
+++ b/docs/source/config/inputs/docker_log.rst
@@ -47,7 +47,7 @@ Config:
 .. versionadded:: 0.10
 
 - name_from_env_var(string):
-		Overwrite the ContainerName with this environmental variable on the Container
+		Overwrite the ContainerName with this environment variable on the Container
 		if exists.
 
 Example:

--- a/docs/source/config/inputs/docker_log.rst
+++ b/docs/source/config/inputs/docker_log.rst
@@ -44,6 +44,12 @@ Config:
     Path to directory containing client certificate and keys. This value works
     in the same way as `DOCKER_CERT_PATH <https://docs.docker.com/articles/https/#client-modes>`_.
 
+.. versionadded:: 0.10
+
+- name_from_env_var(string):
+		Overwrite the ContainerName with this environmental variable on the Container
+		if exists.
+
 Example:
 
 .. code-block:: ini

--- a/plugins/docker/attacher.go
+++ b/plugins/docker/attacher.go
@@ -58,16 +58,17 @@ func (s *Source) All() bool {
 
 type AttachManager struct {
 	sync.RWMutex
-	attached   map[string]*LogPump
-	channels   map[chan *AttachEvent]struct{}
-	client     DockerClient
-	errors     chan<- error
-	events     chan *docker.APIEvents
-	eventReset chan struct{}
-	sentinel   struct{}
+	attached    map[string]*LogPump
+	channels    map[chan *AttachEvent]struct{}
+	client      DockerClient
+	errors      chan<- error
+	events      chan *docker.APIEvents
+	eventReset  chan struct{}
+	sentinel    struct{}
+	nameFromEnv string
 }
 
-func NewAttachManager(endpoint, certPath string, attachErrors chan<- error) (*AttachManager, error) {
+func NewAttachManager(endpoint, certPath string, attachErrors chan<- error, nameFromEnv string) (*AttachManager, error) {
 	var client DockerClient
 	var err error
 
@@ -85,11 +86,12 @@ func NewAttachManager(endpoint, certPath string, attachErrors chan<- error) (*At
 	}
 
 	m := &AttachManager{
-		attached: make(map[string]*LogPump),
-		channels: make(map[chan *AttachEvent]struct{}),
-		client:   client,
-		errors:   attachErrors,
-		events:   make(chan *docker.APIEvents),
+		attached:    make(map[string]*LogPump),
+		channels:    make(map[chan *AttachEvent]struct{}),
+		client:      client,
+		errors:      attachErrors,
+		events:      make(chan *docker.APIEvents),
+		nameFromEnv: nameFromEnv,
 	}
 
 	// Attach to all currently running containers
@@ -124,6 +126,10 @@ func (m *AttachManager) attach(id string) {
 		m.errors <- err
 	}
 	name := container.Name[1:]
+	alt_name := m.changeNameByEnv(container, m.nameFromEnv)
+	if alt_name != "" {
+		name = alt_name
+	}
 	success := make(chan struct{})
 	failure := make(chan error)
 	outrd, outwr := io.Pipe()
@@ -145,6 +151,7 @@ func (m *AttachManager) attach(id string) {
 			close(success)
 			failure <- err
 		}
+
 		m.send(&AttachEvent{Type: "detach", ID: id, Name: name})
 		m.Lock()
 		delete(m.attached, id)
@@ -159,6 +166,16 @@ func (m *AttachManager) attach(id string) {
 		m.send(&AttachEvent{ID: id, Name: name, Type: "attach"})
 		return
 	}
+}
+
+func (m *AttachManager) changeNameByEnv(container *docker.Container, envName string) string {
+	for _, value := range container.Config.Env {
+		valueParts := strings.SplitN(value, "=", 2)
+		if len(valueParts) == 2 && valueParts[0] == envName {
+			return valueParts[1]
+		}
+	}
+	return ""
 }
 
 func (m *AttachManager) send(event *AttachEvent) {


### PR DESCRIPTION
This pull request allow to set in the DockerLogInput a configuration to set the ContainerName using an arbitrary environment variable defined inside the container. Refers to issue https://github.com/mozilla-services/heka/issues/1545

If the environment variable defined on the configuration is not set, it uses the ContainerName instead.

Added on the configuration a new entry name_from_env_var that allows to select the desired variable to use.

Sample configuration: 

(This sample is useful to get the mesos task id instead of the container name, since using Mesos/Marathon the container name does not match the marathon id)

```toml
[hekad]
maxprocs = 2

[Dashboard]
type = "DashboardOutput"
address = ":4352"
ticker_interval = 15

[DockerLogInput]
name_from_env_var = "MESOS_TASK_ID"

[influxdb]
type = "SandboxEncoder"
filename = "lua_encoders/schema_influx.lua"

    [influxdb.config]
    series = "docker"
    skip_fields = "Pid EnvVersion Severity Type"

[InfluxOutput]
message_matcher = "Type == 'DockerLog'"
encoder = "influxdb"
type = "HttpOutput"
address = "http://10.10.10.10:31002/db/logs/series"
username = "root"
password = "root"
```