### PR TITLE
[issue #1554] fix `. build.sh` fails in 0.9.2 tarball release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,12 +100,14 @@ include(CTest)
 include(externals)
 include(mocks)
 
-execute_process(COMMAND "${GIT_EXECUTABLE}" submodule update --init --recursive
-WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-RESULT_VARIABLE error_code
-)
-if(error_code)
-    message(FATAL_ERROR "Failed to init Heka submodules")
+if (INCLUDE_DOCUMENTATION)
+    execute_process(COMMAND "${GIT_EXECUTABLE}" submodule update --init --recursive
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    RESULT_VARIABLE error_code
+    )
+    if(error_code)
+        message(FATAL_ERROR "Failed to init Heka submodules")
+    endif()
 endif()
 
 configure_file("${CMAKE_SOURCE_DIR}/sandbox/lua/lua_sandbox.go.in" "${HEKA_PATH}/sandbox/lua/lua_sandbox.go" @ONLY)


### PR DESCRIPTION
Added `if (INCLUDE_DOCUMENTATION)` block around the `submodule init`
in `CMakeLists.txt`.

fixes #1554 