### PR TITLE
ProcessInput returns incorrect exit status

### DIFF
--- a/plugins/process/process_input.go
+++ b/plugins/process/process_input.go
@@ -214,13 +214,13 @@ func (pi *ProcessInput) Run(ir InputRunner, h PluginHelper) error {
 	pi.exitError = nil
 	pi.ccDone = make(map[string]chan bool)
 	if pi.parseStdout {
-		pi.ccDone["stdout"] = make(chan bool)
+		pi.ccDone["stdout"] = make(chan bool, 1)
 		pi.stdoutDeliverer, pi.stdoutSRunner = pi.initDelivery("stdout")
 		defer pi.stdoutDeliverer.Done()
 	}
 
 	if pi.parseStderr {
-		pi.ccDone["stderr"] = make(chan bool)
+		pi.ccDone["stderr"] = make(chan bool, 1)
 		pi.stderrDeliverer, pi.stderrSRunner = pi.initDelivery("stderr")
 		defer pi.stderrDeliverer.Done()
 	}

--- a/plugins/process/process_input_test.go
+++ b/plugins/process/process_input_test.go
@@ -99,9 +99,17 @@ func ProcessInputSpec(c gs.Context) {
 				c.Expect(string(actual), gs.Equals, PROCESSINPUT_TEST1_OUTPUT+"\n")
 
 				dec := <-decChan
+				select {
+				case pInput.ccDone["stdout"] <- true:
+				default:
+				}
+
 				dec(ith.Pack)
 				fPInputName := ith.Pack.Message.FindFirstField("ProcessInputName")
 				c.Expect(fPInputName.ValueString[0], gs.Equals, "SimpleTest.stdout")
+
+				fPInputName = ith.Pack.Message.FindFirstField("ExitStatus")
+				c.Expect(fPInputName.ValueInteger[0], gs.Equals, int64(0))
 
 				pInput.Stop()
 				err = <-errChan
@@ -132,9 +140,16 @@ func ProcessInputSpec(c gs.Context) {
 				c.Expect(string(actual), gs.Equals, PROCESSINPUT_PIPE_OUTPUT+"\n")
 
 				dec := <-decChan
+				select {
+				case pInput.ccDone["stdout"] <- true:
+				default:
+				}
 				dec(ith.Pack)
 				fPInputName := ith.Pack.Message.FindFirstField("ProcessInputName")
 				c.Expect(fPInputName.ValueString[0], gs.Equals, "PipedCmd.stdout")
+
+				fPInputName = ith.Pack.Message.FindFirstField("ExitStatus")
+				c.Expect(fPInputName.ValueInteger[0], gs.Equals, int64(0))
 
 				pInput.Stop()
 				err = <-errChan


### PR DESCRIPTION
Pack decorator should wait for command chain to finish processing.