### PR TITLE
Change delete_idle_stats default value from false to true

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,6 +17,8 @@ Backwards Incompatibilities
 
 * The 'make deb' target requires fakeroot and debhelper to be installed.
 
+* Switched delete_idle_stats setting default from false to true so unused metrice are not continuously sent forever.
+
 Features
 --------
 

--- a/docs/source/config/inputs/stataccum.rst
+++ b/docs/source/config/inputs/stataccum.rst
@@ -54,7 +54,7 @@ Config:
     Prefix to use for the statsd `numStats` metric. Defaults to "statsd".
 - delete_idle_stats (bool):
     Don't emit values for inactive stats instead of sending 0 or in the case
-    of gauges, sending the previous value. Defaults to false.
+    of gauges, sending the previous value. Defaults to true.
 
 Example:
 

--- a/pipeline/stat_accum_input.go
+++ b/pipeline/stat_accum_input.go
@@ -91,7 +91,7 @@ type StatAccumInputConfig struct {
 	StatsdPrefix     string `toml:"statsd_prefix"`
 
 	// Don't emit values for inactive stats instead of sending 0 or in the case
-	// of gauges, sending the previous value. Defaults to false
+	// of gauges, sending the previous value. Defaults to true
 	DeleteIdleStats bool `toml:"delete_idle_stats"`
 }
 
@@ -107,7 +107,7 @@ func (sm *StatAccumInput) ConfigStruct() interface{} {
 		CounterPrefix:    "counters",
 		TimerPrefix:      "timers",
 		GaugePrefix:      "gauges",
-		DeleteIdleStats:  false,
+		DeleteIdleStats:  true,
 	}
 }
 


### PR DESCRIPTION
Heka has a delete_idle_stats option that is responsible for removing unused statistics.  The default value is false, which means once Heka has seen a stat, it will repeatedly send it forever regardless of weather it sees that stat come in again.  I propose a default value of true, which is far less likely to cause harm.  In practice, stat names change regularly and I've seen Heka routinely cause more than 500,000 unused, worthless stats to be sent to a single Graphite instance every five seconds.  Even a beefy Graphite instance can struggle to keep up with that volume of data, especially since that's not including the actual live data that people want.  Graphite does not include good facilities for identifying where a given stat comes from so identifying Heka as the source of the flood of stats took many man-hours here.  Please save many headaches and remove unused stats by default by setting delete_idle_stats to true out of the box.