### PR TITLE
Fix up Dockerfile for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,44 +1,32 @@
 # heka_base image
-FROM debian:jessie
+FROM golang:1.4
 
 MAINTAINER Chance Zibolski <chance.zibolski@gmail.com> (@chance)
 
 RUN     apt-get update && \
         apt-get install -yq --no-install-recommends \
         build-essential \
-        bzr \
         ca-certificates \
         cmake \
-        curl \
-        git \
-        golang-goprotobuf-dev\
-        make \
-        mercurial \
+        debhelper \
+        fakeroot \
+        libgeoip-dev \
+        libgeoip1 \
+        golang-goprotobuf-dev \
         patch \
         ruby-dev \
         protobuf-compiler \
         python-sphinx \
         wget
 
-# Install Go 1.3.1
-RUN curl -s https://storage.googleapis.com/golang/go1.3.1.linux-amd64.tar.gz -o /tmp/go.tar.gz && \
-        echo "3af011cc19b21c7180f2604fd85fbc4ddde97143 /tmp/go.tar.gz" | sha1sum -c && \
-        tar -C /usr/local -xzf /tmp/go.tar.gz
-
 WORKDIR /heka
-
-ENV GOROOT /usr/local/go
-ENV PATH $PATH:/usr/local/go/bin:/go/bin
 
 ENV CTEST_OUTPUT_ON_FAILURE 1
 ENV BUILD_DIR   /heka/build
 ENV GOPATH      $BUILD_DIR/heka
 ENV GOBIN       $GOPATH/bin
 ENV PATH        $PATH:$GOBIN
-# Build faster
-ENV NUM_JOBS    10
 
 EXPOSE 4352
 
 COPY . /heka
-RUN ./build.sh


### PR DESCRIPTION
* Switch to using the base `golang:1.4` especially considering heka doesn't compile against `1.3.1` anymore.
* Add new/missing dependencies to compile against latest HEAD
* Add libgeoip to enable that functionality
* Remove `NUM_JOBS` because this is broken (not entirely sure why, but seems like a race condition in the build script
* Don't automatically run `build.sh` on creating the container. Since this is local dev, it's more favorable to get a working  environment first, then try to compile, rather than the compilation potentially causing the `docker build` to fail.