### PR TITLE
Stop zero-length records with no error ending the splitter (#1561)

### DIFF
--- a/pipeline/splitter_runner.go
+++ b/pipeline/splitter_runner.go
@@ -331,6 +331,9 @@ func (sr *sRunner) SplitStream(r io.Reader, del Deliverer) error {
 			}
 		}
 		if len(record) == 0 {
+			if err == nil && sr.needData && !sr.reachedEOF {
+				continue
+			}
 			if sr.incompleteFinal && err == io.EOF {
 				record = sr.GetRemainingData()
 				if len(record) > 0 {


### PR DESCRIPTION
Only if there's more data to read and there's no error.
Continue rather than attempting to deliver an empty record.