### PR TITLE
Update Schema InfluxDB Write Encoder to use InfluxDB 0.9.x+ line protocol

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -40,8 +40,8 @@ Features
   compatibility of sending data in Heka message fields to InfluxDB 0.9.0+
   write API. It is required to use this encoder when integrating Heka with an
   InfluxDB 0.9.0+ instance as the API to commit metrics has changed. This
-	encoder was also updated to use the line protocol which is now the default
-	series format for the write API.
+  encoder was also updated to use the line protocol which is now the default
+  series format for the write API.
 
 * Added support for abstract Unix domain sockets to the UdpInput.
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -39,7 +39,9 @@ Features
 * Added a new sandbox encoder, Schema InfluxDB Write Encoder, which updates
   compatibility of sending data in Heka message fields to InfluxDB 0.9.0+
   write API. It is required to use this encoder when integrating Heka with an
-  InfluxDB 0.9.0+ instance as the API to commit metrics has changed.
+  InfluxDB 0.9.0+ instance as the API to commit metrics has changed. This
+	encoder was also updated to use the line protocol which is now the default
+	series format for the write API.
 
 * Added support for abstract Unix domain sockets to the UdpInput.
 


### PR DESCRIPTION
This PR updates the Schema InfluxDB Write Encoder to format metrics into the line protocol instead of the JSON format that was originally proposed for the 0.9.0 release.  This also makes sure that proper formatting is done for the various fields to escape spaces, commas and double quotes as defined by the line protocol.  There is also a somewhat hacky implementation to overcome the fact that Lua converts float values of 0.0 into an integer based on its internal representation of numerical data types.  I've also added a couple of new configuration items that provide more flexibility in the naming of measurements as they are sent to InfluxDB.  There is now more emphasis on utilizing tags instead of the Graphite style "paths" to uniquely identify series, so the defaults have been blanked out to work with this recommendation more naturally.