### PR TITLE
ES dynamic_fields

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -85,6 +85,9 @@ Features
 
 * Dashboard now shows sandbox plugins in alphabetical order.
 
+* Added 'dynamic_fields' config to ESJsonEncoder for
+  selecting a subset of Fields values
+
 Bug Handling
 ------------
 

--- a/docs/source/config/encoders/esjson.rst
+++ b/docs/source/config/encoders/esjson.rst
@@ -36,7 +36,7 @@ Config:
     indexed into ElasticSearch. Available fields to choose are "Uuid",
     "Timestamp", "Type", "Logger", "Severity", "Payload", "EnvVersion", "Pid",
     "Hostname", and "Fields" (where "Fields" causes the inclusion of any and
-    all dynamically specified message fields. Defaults to including all of the
+    all dynamically specified message fields unless dynamic_fields is specified). Defaults to including all of the
     supported message fields.
 - timestamp (string):
     Format to use for timestamps in generated ES documents. Allows to use
@@ -59,6 +59,8 @@ Config:
     Maps Heka message fields to custom ES keys. Can be used to implement a custom format
     in ES or implement Logstash V1. The available fields are "Timestamp", "Uuid",
     "Type", "Logger", "Severity", "Payload", "EnvVersion", "Pid" and "Hostname".
+- dynamic_fields ([]string):
+    This specifies a subset of keys from the dynamic message property to send to ES. Using this option requires setting 'Fields' in the fields configuration.
 
 Example
 


### PR DESCRIPTION
This pull request addresses feedback from #1596.

I have been using the Fields structure to store information for my sandbox plugins and I needed to select just one field for output. The current approach is all or nothing, you can choose to send all "Fields" values or you can choose to send none. I add a new configuration value called "DynamicFields" which lets you specify properties, which if present, will be put in the JSON object. This also support raw encoding of DynamicFields values through "RawBytesFields".

Do not merge: does not yet support the ESLogstashV0Encoder.