### PR TITLE
Don't start if buffer max file size is too small to hold the

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,11 @@ Features
 
 * Allow multiple sandbox module directories to be specified (#1525).
 
+Bug Fixes
+---------
+
+* Validate the buffer max_file_size is greater than MAX_RECORD_SIZE (#1623).
+
 0.10.0b0 (2015-07-13)
 =====================
 

--- a/pipeline/queue_buffer.go
+++ b/pipeline/queue_buffer.go
@@ -87,6 +87,12 @@ func NewBufferSet(queueDir, queueName string, config *QueueBufferConfig,
 		config.CursorUpdateCount = 1
 	}
 
+	if config.MaxFileSize < uint64(message.MAX_RECORD_SIZE) {
+		err := fmt.Errorf("`max_file_size` must be greater than maximum record size of %d",
+			message.MAX_RECORD_SIZE)
+		return nil, nil, err
+	}
+
 	bf, err := NewBufferFeeder(queue, config, queueSize)
 	if err != nil {
 		return nil, nil, fmt.Errorf("can't create BufferFeeder: %s", err)


### PR DESCRIPTION
max size of a message (fixes #1623).