### PR TITLE
Fix #1620, #1644. Unnecessary waiting from decorator.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,6 +17,10 @@ Features
 
 * Allow multiple sandbox module directories to be specified (#1525).
 
+Bug Handling
+------------
+Fixed ProcessInput hangs when splitter is defined (#1620, #1644).
+
 0.10.0b0 (2015-07-13)
 =====================
 

--- a/plugins/process/process_input.go
+++ b/plugins/process/process_input.go
@@ -139,7 +139,6 @@ type ProcessInput struct {
 	stdoutSRunner   SplitterRunner
 	stderrDeliverer Deliverer
 	stderrSRunner   SplitterRunner
-	ccDone          map[string]chan bool
 
 	stopChan  chan bool
 	exitError error
@@ -213,9 +212,7 @@ func (pi *ProcessInput) Run(ir InputRunner, h PluginHelper) error {
 	pi.stopChan = make(chan bool)
 	pi.once = sync.Once{}
 	pi.exitError = nil
-	pi.ccDone = make(map[string]chan bool)
 	if pi.parseStdout {
-		pi.ccDone["stdout"] = make(chan bool, 1)
 		pi.stdoutDeliverer, pi.stdoutSRunner = pi.initDelivery("stdout")
 		defer func() {
 			pi.stdoutDeliverer.Done()
@@ -224,7 +221,6 @@ func (pi *ProcessInput) Run(ir InputRunner, h PluginHelper) error {
 	}
 
 	if pi.parseStderr {
-		pi.ccDone["stderr"] = make(chan bool, 1)
 		pi.stderrDeliverer, pi.stderrSRunner = pi.initDelivery("stderr")
 		defer func() {
 			pi.stderrDeliverer.Done()
@@ -264,7 +260,6 @@ func (pi *ProcessInput) initDelivery(streamName string) (Deliverer, SplitterRunn
 				pi.ir.LogError(err)
 			}
 			// Wait for the result for subcommands.
-			<-pi.ccDone[streamName]
 			// Add exit status and subcommand error messages to pack.
 			var r int
 			if exiterr, ok := pi.ccStatus.ExitStatus.(*exec.ExitError); ok {
@@ -374,14 +369,6 @@ func (pi *ProcessInput) runOnce() {
 		go throwAway(stderrReader)
 	}
 	pi.ccStatus = pi.cc.Wait()
-	// Notify decorators.
-	for key, _ := range pi.ccDone {
-		select { // non-blocking it's a notification.
-		case pi.ccDone[key] <- true:
-		default:
-
-		}
-	}
 }
 
 func (pi *ProcessInput) ParseOutput(r io.Reader, deliverer Deliverer,

--- a/plugins/process/process_input_test.go
+++ b/plugins/process/process_input_test.go
@@ -101,10 +101,6 @@ func ProcessInputSpec(c gs.Context) {
 				c.Expect(string(actual), gs.Equals, PROCESSINPUT_TEST1_OUTPUT+"\n")
 
 				dec := <-decChan
-				select {
-				case pInput.ccDone["stdout"] <- true:
-				default:
-				}
 
 				dec(ith.Pack)
 				fPInputName := ith.Pack.Message.FindFirstField("ProcessInputName")
@@ -142,10 +138,7 @@ func ProcessInputSpec(c gs.Context) {
 				c.Expect(string(actual), gs.Equals, PROCESSINPUT_PIPE_OUTPUT+"\n")
 
 				dec := <-decChan
-				select {
-				case pInput.ccDone["stdout"] <- true:
-				default:
-				}
+
 				dec(ith.Pack)
 				fPInputName := ith.Pack.Message.FindFirstField("ProcessInputName")
 				c.Expect(fPInputName.ValueString[0], gs.Equals, "PipedCmd.stdout")


### PR DESCRIPTION
Fix #1620 and  #1644. Unnecessary waiting from decorator, it's only invoked after the input is parsed and handled.