### PR TITLE
only apply the CWD change to the make context via subshell

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,7 @@ NUM_JOBS=${NUM_JOBS:-1}
 
 # build heka
 mkdir -p $BUILD_DIR
-cd $BUILD_DIR
+(cd $BUILD_DIR
 cmake -DCMAKE_BUILD_TYPE=release ..
 make -j $NUM_JOBS
+)


### PR DESCRIPTION
this way, if the script exits for whatever reason, you're still
in the same directory and can easily run the same command again.
otherwise you always have to cd one level up.