### PR TITLE
Added `SplitStreamNullSplitterToEOF` to SplitterRunner

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,12 @@ Features
 --------
 
 * Allow multiple sandbox module directories to be specified (#1525).
-* Add Nginx stub status lua sandbox decoder
+
+* Add Nginx stub status lua sandbox decoder.
+
+* Added `SplitStreamNullSplitterToEOF` to SplitterRunner interface so input
+  plugins can avoid generating messages with whatever happens to come back from
+  a `Read()` call.
 
 Bug Handling
 ------------
@@ -13,6 +18,9 @@ Bug Handling
 * Validate the buffer max_file_size is greater than MAX_RECORD_SIZE (#1623).
 
 * Fixed ProcessInput hangs when splitter is defined (#1620, #1644).
+
+* Fixed ProcessInput not getting process's full output when NullSplitter is in
+  use (#1645).
 
 0.10.0b0 (2015-07-13)
 =====================

--- a/plugins/http/http_input.go
+++ b/plugins/http/http_input.go
@@ -186,10 +186,11 @@ func (hi *HttpInput) fetchUrl(url string, sRunner SplitterRunner) {
 		sRunner.SetPackDecorator(hi.makePackDecorator(respData))
 	}
 
-	err = splitStream(hi.ir, sRunner, resp.Body)
+	err = sRunner.SplitStreamNullSplitterToEOF(resp.Body, nil)
 	if err != nil && err != io.EOF {
 		hi.ir.LogError(fmt.Errorf("fetching %s response input: %s", url, err.Error()))
 	}
+	resp.Body.Close()
 }
 
 func (hi *HttpInput) Run(ir InputRunner, h PluginHelper) (err error) {

--- a/plugins/http/http_listen_input.go
+++ b/plugins/http/http_listen_input.go
@@ -198,10 +198,11 @@ func (hli *HttpListenInput) RequestHandler(w http.ResponseWriter, req *http.Requ
 		if !sRunner.UseMsgBytes() {
 			sRunner.SetPackDecorator(hli.makePackDecorator(req))
 		}
-		err = splitStream(hli.ir, sRunner, req.Body)
+		err = sRunner.SplitStreamNullSplitterToEOF(req.Body, nil)
 		if err != nil && err != io.EOF {
 			hli.ir.LogError(fmt.Errorf("receiving request body: %s", err.Error()))
 		}
+		req.Body.Close()
 		sRunner.Done()
 	}
 }

--- a/plugins/http/http_util.go
+++ b/plugins/http/http_util.go
@@ -1,12 +1,6 @@
 package http
 
-import (
-	"fmt"
-	"github.com/mozilla-services/heka/message"
-	p "github.com/mozilla-services/heka/pipeline"
-	"io"
-	"net/http"
-)
+import "net/http"
 
 func CustomHeadersHandler(h http.Handler, header http.Header) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -17,55 +11,4 @@ func CustomHeadersHandler(h http.Handler, header http.Header) http.Handler {
 		}
 		h.ServeHTTP(w, r)
 	})
-}
-
-func splitStream(ir p.InputRunner, sRunner p.SplitterRunner, r io.ReadCloser) error {
-	var (
-		record       []byte
-		longRecord   []byte
-		err          error
-		deliver      bool
-		nullSplitter bool
-	)
-	// If we're using a NullSplitter we want to make sure we capture the
-	// entire HTTP request or response body and not be subject to what we get
-	// from a single Read() call.
-	if _, ok := sRunner.Splitter().(*p.NullSplitter); ok {
-		nullSplitter = true
-	}
-	for err == nil {
-		deliver = true
-		_, record, err = sRunner.GetRecordFromStream(r)
-		if err == io.ErrShortBuffer {
-			if sRunner.KeepTruncated() {
-				err = fmt.Errorf("record exceeded MAX_RECORD_SIZE %d and was truncated",
-					message.MAX_RECORD_SIZE)
-			} else {
-				deliver = false
-				err = fmt.Errorf("record exceeded MAX_RECORD_SIZE %d and was dropped",
-					message.MAX_RECORD_SIZE)
-			}
-			ir.LogError(err)
-			err = nil // non-fatal, keep going
-		} else if sRunner.IncompleteFinal() && err == io.EOF && len(record) == 0 {
-			record = sRunner.GetRemainingData()
-		}
-		if len(record) > 0 && deliver {
-			if nullSplitter {
-				// Concatenate all the records until EOF. This should be safe
-				// b/c NullSplitter means FindRecord will always return the
-				// full buffer contents, we don't have to worry about
-				// GetRecordFromStream trying to append multiple reads to a
-				// single record and triggering an io.ErrShortBuffer error.
-				longRecord = append(longRecord, record...)
-			} else {
-				sRunner.DeliverRecord(record, nil)
-			}
-		}
-	}
-	r.Close()
-	if err == io.EOF && nullSplitter && len(longRecord) > 0 {
-		sRunner.DeliverRecord(longRecord, nil)
-	}
-	return err
 }

--- a/plugins/process/process_input.go
+++ b/plugins/process/process_input.go
@@ -373,7 +373,7 @@ func (pi *ProcessInput) runOnce() {
 
 func (pi *ProcessInput) ParseOutput(r io.Reader, deliverer Deliverer,
 	sRunner SplitterRunner) {
-	err := sRunner.SplitStream(r, deliverer)
+	err := sRunner.SplitStreamNullSplitterToEOF(r, deliverer)
 	// Go doesn't seem to have a good solution to streaming output
 	// between subprocesses.  It seems like you have to read *all* the
 	// content in a goroutine instead of just streaming the content.

--- a/plugins/process/process_input_test.go
+++ b/plugins/process/process_input_test.go
@@ -65,7 +65,7 @@ func ProcessInputSpec(c gs.Context) {
 		})
 
 		bytesChan := make(chan []byte, 1)
-		splitCall := ith.MockSplitterRunner.EXPECT().SplitStream(gomock.Any(),
+		splitCall := ith.MockSplitterRunner.EXPECT().SplitStreamNullSplitterToEOF(gomock.Any(),
 			ith.MockDeliverer).Return(nil)
 		splitCall.Do(func(r io.Reader, del Deliverer) {
 			bytes, err := ioutil.ReadAll(r)


### PR DESCRIPTION
interface, updated HttpInput, HttpListenInput, ProcessInput to
use it. Fixes #1645.