### PR TITLE
Config option for TcpOutut connection re-establishment

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,6 +19,8 @@ Features
 
 * Allow multiple sandbox module directories to be specified (#1525).
 * Add Nginx stub status lua sandbox decoder
+* Allow TcpOutput to re-establish the connection after a configurable number
+  of successfully delivered messages.
 
 Bug Fixes
 ---------

--- a/docs/source/config/outputs/tcp.rst
+++ b/docs/source/config/outputs/tcp.rst
@@ -55,6 +55,9 @@ Config:
     All of the :ref:`buffering <buffering>` config options are set to the
     standard default options, except for `cursor_update_count`, which is set to
     50 instead of the standard default of 1.
+- reconnect_after (int, optional):
+    Re-establish the TCP connection after the specified number of successfully
+    delivered messages.  Defaults to 0 (no reconnection).
 
 Example:
 

--- a/plugins/tcp/tcp_output.go
+++ b/plugins/tcp/tcp_output.go
@@ -61,6 +61,9 @@ type TcpOutputConfig struct {
 	KeepAlive bool `toml:"keep_alive"`
 	// Integer indicating seconds between keep alives.
 	KeepAlivePeriod int `toml:"keep_alive_period"`
+	// Number of successfully processed messages to re-establish the TCP
+	// connection after.  Defaults to 0 (never)
+	ReconnectAfter int64 `toml:"reconnect_after"`
 	// Specifies whether or not Heka's stream framing wil be applied to the
 	// output. We do some magic to default to true if ProtobufEncoder is used,
 	// false otherwise.
@@ -166,6 +169,9 @@ func (t *TcpOutput) ProcessMessage(pack *PipelinePack) (err error) {
 	} else {
 		atomic.AddInt64(&t.processMessageCount, 1)
 		t.or.UpdateCursor(pack.QueueCursor)
+		if t.conf.ReconnectAfter > 0 && atomic.LoadInt64(&t.processMessageCount)%t.conf.ReconnectAfter == 0 {
+			t.cleanupConn()
+		}
 	}
 
 	return err


### PR DESCRIPTION
This feature would be useful in a couple of places:
* For destinations that only support 1 payload per TCP connection, like the [Zabbix agent "active check"](https://www.zabbix.com/documentation/2.4/manual/appendix/items/activepassive) protocol, which closes the connection causing Heka to spit out an error and lose every other message.
* To help balance up long-running connections hitting RRDNS-based VIPs.

Reconnections are based on the successfully processed messages counter, and the config value defaults to 0 (no connection re-establishment, the current behaviour).