### PR TITLE
Force ES index name to lower case

### DIFF
--- a/plugins/elasticsearch/coordinates.go
+++ b/plugins/elasticsearch/coordinates.go
@@ -47,7 +47,7 @@ func (e *ElasticSearchCoordinates) PopulateBuffer(m *message.Message, buf *bytes
 
 	interpIndex, err = interpolateFlag(e, m, e.Index)
 
-	buf.WriteString(strconv.Quote(interpIndex))
+	buf.WriteString(strconv.Quote(strings.ToLower(interpIndex)))
 	buf.WriteString(`,"_type":`)
 
 	interpType, err = interpolateFlag(e, m, e.Type)


### PR DESCRIPTION
See https://www.elastic.co/guide/en/elasticsearch/guide/current/_document_metadata.html#_index:
This name must be lowercase, cannot begin with an underscore, and cannot contain commas.