### PR TITLE
Bring Dockerfile's up to date

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # heka_base image
-FROM debian:jessie
+FROM golang:1.4
 
 MAINTAINER Chance Zibolski <chance.zibolski@gmail.com> (@chance)
 
@@ -18,27 +18,15 @@ RUN     apt-get update && \
         ruby-dev \
         protobuf-compiler \
         python-sphinx \
-        wget
-
-# Install Go 1.3.1
-RUN curl -s https://storage.googleapis.com/golang/go1.3.1.linux-amd64.tar.gz -o /tmp/go.tar.gz && \
-        echo "3af011cc19b21c7180f2604fd85fbc4ddde97143 /tmp/go.tar.gz" | sha1sum -c && \
-        tar -C /usr/local -xzf /tmp/go.tar.gz
+        wget \
+        debhelper \
+        fakeroot \
+        libgeoip-dev \
+        libgeoip1 \
+        golang-goprotobuf-dev
 
 WORKDIR /heka
-
-ENV GOROOT /usr/local/go
-ENV PATH $PATH:/usr/local/go/bin:/go/bin
-
-ENV CTEST_OUTPUT_ON_FAILURE 1
-ENV BUILD_DIR   /heka/build
-ENV GOPATH      $BUILD_DIR/heka
-ENV GOBIN       $GOPATH/bin
-ENV PATH        $PATH:$GOBIN
-# Build faster
-ENV NUM_JOBS    10
 
 EXPOSE 4352
 
 COPY . /heka
-RUN ./build.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,8 +3,10 @@
 # and builds a new image which installs that dpkg
 FROM mozilla/heka_base
 
+RUN cd /heka && . ./build.sh
+RUN cd /heka && . ./env.sh && cd /heka/build && make deb
+
 RUN mkdir -p /heka_docker
-RUN cd /heka/build && make deb
 RUN find /heka/build -name "*.deb" -exec cp {} /heka_docker/heka.deb \;
 COPY Dockerfile.final /heka_docker/Dockerfile
 

--- a/docker/Dockerfile.final
+++ b/docker/Dockerfile.final
@@ -4,6 +4,7 @@ FROM debian:jessie
 MAINTAINER Chance Zibolski <chance.zibolski@gmail.com> (@chance)
 
 COPY heka.deb /tmp/heka.deb
+RUN apt-get update && apt-get install -y libgeoip1
 RUN dpkg -i /tmp/heka.deb && rm /tmp/heka.deb
 
 EXPOSE 4352


### PR DESCRIPTION
There was previous work for fixing Docker builds here: https://github.com/mozilla-services/heka/pull/1566 . Work was only done for development environment and the original author hasn't gotten back to feedback.

This PR fixes the development, build, and release Dockerfiles. You should be able to follow the documentation in `/docker` and get yourself a release image.