### PR TITLE
Bad EXEC for starting up heka container

### DIFF
--- a/docker/Dockerfile.final
+++ b/docker/Dockerfile.final
@@ -8,4 +8,4 @@ RUN apt-get update && apt-get install -y libgeoip1
 RUN dpkg -i /tmp/heka.deb && rm /tmp/heka.deb
 
 EXPOSE 4352
-ENTRYPOINT ["hekad"]
+ENTRYPOINT ["hekad", "-config=/etc/heka/conf.d"]

--- a/docker/build_docker.sh
+++ b/docker/build_docker.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e
+# verbose/exit on error
+set -xe
 docker build -t mozilla/heka_base ..
 docker build --rm -t mozilla/heka_build .
 docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -ti mozilla/heka_build


### PR DESCRIPTION
The EXEC statement will never succeed because of how the debian package places the default config file.