### PR TITLE
Allows passing of CMAKE options when sourcing build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,5 +8,5 @@ NUM_JOBS=${NUM_JOBS:-1}
 # build heka
 mkdir -p $BUILD_DIR
 cd $BUILD_DIR
-cmake -DCMAKE_BUILD_TYPE=release ..
+cmake -DCMAKE_BUILD_TYPE=release $@ ..
 make -j $NUM_JOBS


### PR DESCRIPTION
Hi there,

Given the recommended building process is to source build.sh I thought it may be a good idea to allow users to pass cmake parameters during the source (rather than requiring them to rebuild the package)