### PR TITLE
Account for the case where the file that matches our lookup id is

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -29,6 +29,8 @@ Bug Handling
 * Fixed bug where a SandboxInput configured with a `ticker_interval` would
   get stuck in an infinite loop on shutdown (#1705).
 
+* Fixed race condition in the BufferReader's queue file lookup code (#1639).
+
 0.10.0b1 (2015-08-07)
 =====================
 

--- a/pipeline/queue_buffer.go
+++ b/pipeline/queue_buffer.go
@@ -329,7 +329,8 @@ func (br *BufferReader) getFileFromId(id uint) (file *os.File, foundId uint,
 		return nil, 0, nil
 	}
 
-	// Increment until we find an id greater than what was requested.
+	// Increment until we find an id greater than or equal to what was
+	// requested.
 	for _, val := range ids {
 		if val >= id {
 			foundId = val

--- a/pipeline/queue_buffer.go
+++ b/pipeline/queue_buffer.go
@@ -319,8 +319,10 @@ func (br *BufferReader) getFileFromId(id uint) (file *os.File, foundId uint,
 		return file, foundId, err
 	}
 
-	// If we got this far there's no file matching our id, try to find the
-	// next one above.
+	// If we got this far, there was no file matching our id when we checked.
+	// It might, however, have been created after we checked, but before we get
+	// our id list back from the sortedBufferIds call below. This is fine,
+	// we'll still find and return it.
 	ids := sortedBufferIds(br.queue)
 	if len(ids) == 0 || ids[len(ids)-1] < id {
 		// No log file for us, not an error.
@@ -329,7 +331,7 @@ func (br *BufferReader) getFileFromId(id uint) (file *os.File, foundId uint,
 
 	// Increment until we find an id greater than what was requested.
 	for _, val := range ids {
-		if val > id {
+		if val >= id {
 			foundId = val
 			break
 		}


### PR DESCRIPTION
created after we look for it directly but before we get the full list
of files from the queue folder.