### PR TITLE
Bump Lua Sandbox (Relates to: #1329)

### DIFF
--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -19,7 +19,7 @@ if(INCLUDE_SANDBOX)
     externalproject_add(
         ${SANDBOX_PACKAGE}
         GIT_REPOSITORY https://github.com/mozilla-services/lua_sandbox.git
-        GIT_TAG 82ae00d85f3111ee77bf15dbcb97264f177a66ec
+        GIT_TAG bf6e1d0c13e7c3e0a7b526e75a6f9fa7cf80b529
         CMAKE_ARGS ${SANDBOX_ARGS}
         INSTALL_DIR ${PROJECT_PATH}
     )


### PR DESCRIPTION
as highlighted in issue #1329 maybe it is worth bumping the lua sandbox git commit. Tests seem to pass just fine. No lost functionality in here so far.

````
heka$ source build.sh
...
100% tests passed, 0 tests failed out of 26
Total Test time (real) =  22.17 sec
````