### PR TITLE
Rpm install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,9 +96,11 @@ elseif(UNIX)
         set(CPACK_GENERATOR ${CPACK_GENERATOR} "RPM")
         set(CPACK_RPM_PACKAGE_LICENSE "MPLv2.0")
         set(CPACK_RPM_PACKAGE_DESCRIPTION "Heka is a tool for collecting and collating data from a number of different sources, performing 'in-flight' processing of collected data, and delivering the results to any number of destinations for further analysis.")
-		# todo we should pull lua_sandbox out of the heka/build and packaging
-		set(CPACK_RPM_PACKAGE_PROVIDES "libluasb.so.0()(64bit), libluasandbox.so.0()(64bit)")
-		set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION /usr/share/man)
+	# todo we should pull lua_sandbox out of the heka/build and packaging
+	set(CPACK_RPM_PACKAGE_PROVIDES "libluasb.so.0()(64bit), libluasandbox.so.0()(64bit)")
+	set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION /usr/share/man)
+        set(CPACK_RPM_PACKAGE_REQUIRES_PRE "shadow-utils")
+        set(CPACK_RPM_PRE_INSTALL_SCRIPT_FILE "${CMAKE_SOURCE_DIR}/rpm/heka.preinst.in")
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ elseif(UNIX)
 	set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION /usr/share/man)
         set(CPACK_RPM_PACKAGE_REQUIRES_PRE "shadow-utils")
         set(CPACK_RPM_PRE_INSTALL_SCRIPT_FILE "${CMAKE_SOURCE_DIR}/rpm/heka.preinst.in")
+        set(CPACK_RPM_POST_INSTALL_SCRIPT_FILE "${CMAKE_SOURCE_DIR}/rpm/heka.postinst.in")
     endif()
 endif()
 

--- a/rpm/heka.postinst.in
+++ b/rpm/heka.postinst.in
@@ -1,0 +1,5 @@
+set -eu
+
+install -d -m0755 -oroot -groot /etc/heka/conf.d/
+install -m0744 -oroot -groot -T /usr/share/heka/examples/hekad.toml /etc/heka/conf.d/00-hekad.toml
+exit 0

--- a/rpm/heka.preinst.in
+++ b/rpm/heka.preinst.in
@@ -1,0 +1,8 @@
+USER="heka"
+GROUP=$USER
+HOMEBASE=/var/cache/hekad 
+
+getent group $GROUP >/dev/null || groupadd -r $GROUP
+getent passwd $USER >/dev/null || useradd -r -g $GROUP -M -d $HOMEBASE -s /sbin/nologin -c "heka daemon" $USER
+install -d -m0755 -o$USER -g$GROUP $HOMEBASE
+exit 0


### PR DESCRIPTION
* Introduce pre and post install scripts into the RPM CPack configuration. 
* The scripts closely mimic the Debian installer and:
  - create heka user;
  - create heka group;
  - create heka home folder at /var/run/hekad
  - create /etc/heka/conf.d
  - copy /usr/share/heka/examples/hekad.toml into 
    /etc/heka/conf.d/00-hekad.toml