### PR TITLE
Read the whole http response.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,11 @@ Bug Handling
 * Updated Sarama dependency from pre-1.0 release fork to fork (with only test
   code changes) of Sarama 1.5.0 release.
 
+* Ensure the response is read until it is complete in the HttpOutput plugin.
+  Previously, the deferred Body.Close() may have been called on incomplete
+  responses. This resulted in the connections not returning to the client's
+  Transport connection pool.
+
 Features
 --------
 

--- a/plugins/http/http_output.go
+++ b/plugins/http/http_output.go
@@ -148,6 +148,7 @@ func (o *HttpOutput) request(or pipeline.OutputRunner, outBytes []byte) (err err
 		return fmt.Errorf("Error making HTTP request: %s", err.Error())
 	}
 	defer resp.Body.Close()
+	io.Copy(ioutil.Discard, resp.Body)
 
 	if resp.StatusCode >= 400 {
 		body, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
Without requiring the full response is read prior to returning, the
closing of the response body might not work, resulting in many sockets in
the TIME_WAIT state.