### PR TITLE
Exit cleanly (vs panic) if we get a config that registers no plugins.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -66,6 +66,9 @@ Bug Handling
   responses. This resulted in the connections not returning to the client's
   Transport connection pool.
 
+* Fixed panic that was occurring when loading a config file or directory that
+  exists but which registers no plugins (#1597).
+
 0.10.0b1 (2015-08-07)
 =====================
 

--- a/pipeline/config.go
+++ b/pipeline/config.go
@@ -677,6 +677,10 @@ func (self *PipelineConfig) LoadConfig() error {
 	}
 
 	makersByCategory := self.makersByCategory
+	if len(makersByCategory) == 0 {
+		return errors.New("Empty configuration, exiting.")
+	}
+
 	var err error
 
 	multiDecoders := make([]multiDecoderNode, len(makersByCategory["MultiDecoder"]))


### PR DESCRIPTION
Fixes  #1597.