### PR TITLE
ElasticSearch HTTP output: improve error reporting

### DIFF
--- a/plugins/elasticsearch/elasticsearch.go
+++ b/plugins/elasticsearch/elasticsearch.go
@@ -408,21 +408,21 @@ func (h *HttpBulkIndexer) Index(body []byte) (err error, retry bool) {
 	}
 	if response != nil {
 		defer response.Body.Close()
-		if response.StatusCode > 304 {
-			return fmt.Errorf("HTTP response error status: %s", response.Status), false
-		}
 		if response_body, err = ioutil.ReadAll(response.Body); err != nil {
-			return fmt.Errorf("Can't read HTTP response body: %s", err.Error()), true
+			return fmt.Errorf("Can't read HTTP response body. Status: %d. Error: %s", response.Status, err.Error()), true
 		}
 		err = json.Unmarshal(response_body, &response_body_json)
 		if err != nil {
-			return fmt.Errorf("HTTP response didn't contain valid JSON. Body: %s",
-				string(response_body)), true
+			return fmt.Errorf("HTTP response didn't contain valid JSON. Status: %d. Body: %s",
+				response.Status, string(response_body)), true
 		}
 		json_errors, ok := response_body_json["errors"].(bool)
 		if ok && json_errors {
-			return fmt.Errorf("ElasticSearch server reported error within JSON: %s",
-				string(response_body)), false
+			return fmt.Errorf("ElasticSearch server reported error within JSON. Status: %d. Body: %s",
+				response.Status, string(response_body)), false
+		}
+		if response.StatusCode > 304 {
+			return fmt.Errorf("HTTP response error status: %s", response.Status), false
 		}
 	}
 	return nil, false


### PR DESCRIPTION
- HTTP status always reported
- HTTP status >= 304 errors reported