### PR TITLE
Fix restart for the AMQP input plugin

### DIFF
--- a/plugins/amqp/amqp_input.go
+++ b/plugins/amqp/amqp_input.go
@@ -175,7 +175,7 @@ func (ai *AMQPInput) Run(ir InputRunner, h PluginHelper) (err error) {
 	stream, err := ai.ch.Consume(ai.config.Queue, "", false, ai.config.QueueExclusive,
 		false, false, nil)
 	if err != nil {
-		return
+		return fmt.Errorf("Cannot consume from queue %s: %s", ai.config.Queue, err)
 	}
 
 	sRunner := ir.NewSplitterRunner("")
@@ -203,7 +203,8 @@ func (ai *AMQPInput) Run(ir InputRunner, h PluginHelper) (err error) {
 		}
 		msg.Ack(false)
 	}
-	return nil
+	// return an error message to trigger a potential restart of the plugin
+	return fmt.Errorf("Channel closed while reading from queue %s",  ai.config.Queue)
 }
 
 func (ai *AMQPInput) CleanupForRestart() {

--- a/plugins/amqp/amqp_test.go
+++ b/plugins/amqp/amqp_test.go
@@ -183,7 +183,6 @@ func AMQPPluginSpec(c gs.Context) {
 			c.Expect(string(msgBytes), gs.Equals, string(msgBody))
 			close(streamChan)
 			err = <-errChan
-			c.Expect(err, gs.IsNil)
 		})
 	})
 


### PR DESCRIPTION
This change modifies the Run() method to return something other than
nil when the connection to the AMQP server drops. This is partial fix
for bug #1757.