### PR TITLE
Use io.ReadFull to prevent situation where gzip.Reader doesn't fill the buffer

### DIFF
--- a/logstreamer/reader.go
+++ b/logstreamer/reader.go
@@ -422,7 +422,7 @@ func SeekInFile(path string, position *LogstreamLocation) (*os.File, io.Reader, 
 		expectedN int64
 	)
 	if seekPos >= 0 {
-		n, err = reader.Read(buf)
+		n, err = io.ReadFull(reader, buf)
 		expectedN = int64(LINEBUFFERLEN)
 	} else {
 		n, err = reader.Read(buf[-seekPos:])


### PR DESCRIPTION
I ran into this issue trying to ship some old log files. I traced it to this read. The issue is that the gzip.Reader was not returning the full `LINEBUFFERLEN` bytes, but also not returning an error. I'm assuming it has something to do with blocks inside of gzip files.

It was resulting in the same file being considered to be a new file which caused the LogStreamerInput to jump back to the beginning of the file and start reading it again, over and over.

This issue is still present in 0.10 as well.