### PR TITLE
Use io.ReadFull to ensure full content is read when checking position hash

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -84,6 +84,9 @@ Bug Handling
 * Fixed panic that was occurring when loading a config file or directory that
   exists but which registers no plugins (#1597).
 
+* Fixed bug where LogStreamerInput would sometimes loop infinitely reading the
+  same file over and over when reading gzipped log files.
+
 0.10.0b1 (2015-08-07)
 =====================
 

--- a/logstreamer/reader.go
+++ b/logstreamer/reader.go
@@ -410,7 +410,7 @@ func SeekInFile(path string, position *LogstreamLocation) (*os.File, io.Reader, 
 		expectedN int64
 	)
 	if seekPos >= 0 {
-		n, err = reader.Read(buf)
+		n, err = io.ReadFull(reader, buf)
 		expectedN = int64(LINEBUFFERLEN)
 	} else {
 		n, err = reader.Read(buf[-seekPos:])


### PR DESCRIPTION
As per #1770, here's the PR against 0.10. I'm glad to see that the same change on 0.10 didn't cause any tests to fail as it did against 0.9.