### PR TITLE
Converts Kafka output to Synchronous publisher 

### DIFF
--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -19,7 +19,7 @@ if(INCLUDE_SANDBOX)
     externalproject_add(
         ${SANDBOX_PACKAGE}
         GIT_REPOSITORY https://github.com/mozilla-services/lua_sandbox.git
-        GIT_TAG 82ae00d85f3111ee77bf15dbcb97264f177a66ec
+        GIT_TAG bf6e1d0c13e7c3e0a7b526e75a6f9fa7cf80b529
         CMAKE_ARGS ${SANDBOX_ARGS}
         INSTALL_DIR ${PROJECT_PATH}
     )

--- a/docs/source/installing.rst
+++ b/docs/source/installing.rst
@@ -34,7 +34,6 @@ Prerequisites (all systems):
 - CMake 3.0.0 or greater http://www.cmake.org/cmake/resources/software.html
 - Git http://git-scm.com/download
 - Go 1.4 or greater http://golang.org/dl/
-- Mercurial http://mercurial.selenic.com/wiki/Download
 - Protobuf 2.3 or greater (optional - only needed if message.proto is modified) http://code.google.com/p/protobuf/downloads/list
 - Sphinx (optional - used to generate the documentation) http://sphinx-doc.org/
 - An internet connection to fetch sub modules


### PR DESCRIPTION
* Converts Kafka publisher to synchronous publisher resulting in better control of delivery failures; #1750
* Introduces buffering to Heka's kafka at the expense of some performance. #1749

* Update the documentation to reflect drop of the Mercurial requirements ##1736