### PR TITLE
Changing Inject to Deliver in StatAccumInput to allow Decoders

### DIFF
--- a/pipeline/stat_accum_input.go
+++ b/pipeline/stat_accum_input.go
@@ -263,7 +263,7 @@ func (sm *StatAccumInput) Flush() {
 	countPercentThreshold := len(sm.config.PercentThreshold)
 	for key, timings := range sm.timers {
 		timerNs := globalNs.Namespace(sm.config.TimerPrefix).Namespace(key)
-		var min, max, sum, mean, rate, thresholdBoundary  float64
+		var min, max, sum, mean, rate, thresholdBoundary float64
 		meanPercentile := make([]float64, countPercentThreshold)
 		upperPercentile := make([]float64, countPercentThreshold)
 		count := len(timings)
@@ -281,7 +281,7 @@ func (sm *StatAccumInput) Flush() {
 			max = timings[count-1]
 			mean = min
 
-			for i := 0; i < countPercentThreshold; i++{
+			for i := 0; i < countPercentThreshold; i++ {
 				tmp := ((100.0 - float64(sm.config.PercentThreshold[i])) / 100.0) * float64(count)
 				numInThreshold := count - int(math.Floor(tmp+0.5)) // simulate JS Math.round(x)
 
@@ -338,7 +338,7 @@ func (sm *StatAccumInput) Flush() {
 	pack.Message.SetHostname(sm.pConfig.hostname)
 	pack.Message.SetPid(sm.pConfig.pid)
 	pack.Message.SetPayload(buffer.String())
-	sm.ir.Inject(pack)
+	sm.ir.Deliver(pack)
 }
 
 type statsEmitters struct {


### PR DESCRIPTION
Recently encountered that you couldn't add Decoders to StatAccumInput when we wanted to add server fields that generally go into the series name as tags instead for the new InfluxDB schema and tried via adding a ScribbleDecoder and it didn't work! Turned out it was because StatAccumInput was using Inject on the InputRunner instead of the newer Deliver which invokes decoders. :)

My auto-formatting also "corrected" a couple of things in the file, it would seem!