### PR TITLE
RstEncoder: Fix Timestamp value and change it to Local format

### DIFF
--- a/plugins/rst_encoder.go
+++ b/plugins/rst_encoder.go
@@ -79,7 +79,7 @@ func (re *RstEncoder) Encode(pack *pipeline.PipelinePack) (output []byte, err er
 	// Writing out the message attributes is easy.
 	buf := new(bytes.Buffer)
 	buf.WriteString("\n")
-	timestamp := time.Unix(0, pack.Message.GetTimestamp()).UTC()
+	timestamp := time.Unix(pack.Message.GetTimestamp(), 0).Local()
 	re.writeAttr(buf, "Timestamp", timestamp.String())
 	re.writeAttr(buf, "Type", pack.Message.GetType())
 	re.writeAttr(buf, "Hostname", pack.Message.GetHostname())


### PR DESCRIPTION
- The value of Message.GetTimestamp() is seconds not nanoseconds,
  it should be passed into time.Unix(sec, nsec) as first argument.

- Convert timestamp to Local format instead of UTC will be more
  user friendly.

Signed-off-by: Yunkai Zhang <qiushu.zyk@taobao.com>