### PR TITLE
Add CloseAfterWrite option to the TcpOutput

### DIFF
--- a/docs/source/config/outputs/tcp.rst
+++ b/docs/source/config/outputs/tcp.rst
@@ -55,6 +55,11 @@ Config:
     All of the :ref:`buffering <buffering>` config options are set to the
     standard default options, except for `cursor_update_count`, which is set to
     50 instead of the standard default of 1.
+- close_after_write (bool, optional):
+    Specifies whether or not the TCP socket should be closed after Heka
+    successfully writes a message. This option exists to deal with buggy TCP
+    servers that close their socket before our Heka client does. This should
+    only be enabled if you absolutely need it. Defaults to false.
 
 Example:
 

--- a/plugins/tcp/tcp_output.go
+++ b/plugins/tcp/tcp_output.go
@@ -61,6 +61,10 @@ type TcpOutputConfig struct {
 	KeepAlive bool `toml:"keep_alive"`
 	// Integer indicating seconds between keep alives.
 	KeepAlivePeriod int `toml:"keep_alive_period"`
+	// Specifies whether or not Heka should close the TCP socket after
+	// successfully writing out a message. This exists to deal with buggy TCP
+	// servers that close their sockets after clients write out their message.
+	CloseAfterWrite bool `toml:"close_after_write"`
 	// Specifies whether or not Heka's stream framing wil be applied to the
 	// output. We do some magic to default to true if ProtobufEncoder is used,
 	// false otherwise.
@@ -79,10 +83,11 @@ func (t *TcpOutput) ConfigStruct() interface{} {
 		FullAction:        "shutdown",
 	}
 	return &TcpOutputConfig{
-		Address:      "localhost:9125",
-		Encoder:      "ProtobufEncoder",
-		UseBuffering: &b,
-		Buffering:    queueConfig,
+		Address:         "localhost:9125",
+		Encoder:         "ProtobufEncoder",
+		CloseAfterWrite: false,
+		UseBuffering:    &b,
+		Buffering:       queueConfig,
 	}
 }
 
@@ -166,6 +171,9 @@ func (t *TcpOutput) ProcessMessage(pack *PipelinePack) (err error) {
 	} else {
 		atomic.AddInt64(&t.processMessageCount, 1)
 		t.or.UpdateCursor(pack.QueueCursor)
+		if t.conf.CloseAfterWrite {
+			t.cleanupConn()
+		}
 	}
 
 	return err


### PR DESCRIPTION
This PR adds an option to the TcpOuput plugin that closes the socket after successfully writing a message. This is to deal with TCP servers that close their sockets without SO_LINGER enabled.

I discovered this issue while trying to write a JSON payload to Sensu which closes its side of the TCP connection after reading up to a newline. When that happens, the TCP socket on the Heka side transitions to CLOSE_WAIT and is stuck there until we try and write another message. Here is an example:

```
# lsof -i:3030 -P -n
COMMAND     PID  USER   FD   TYPE    DEVICE SIZE/OFF NODE NAME
sensu-cli  4809 sensu   10u  IPv4  85956468      0t0  TCP 127.0.0.1:3030 (LISTEN)
sensu-cli  4809 sensu   11u  IPv4  85956469      0t0  UDP 127.0.0.1:3030 
hekad     11504  root   21u  IPv4 203961716      0t0  TCP 127.0.0.1:43054->127.0.0.1:3030 (CLOSE_WAIT)
```

Unfortunately (at least on Linux) the kernel will still accept writes on the file descriptor despite the TCP socket being in CLOSE_WAIT. The result is that when we write that second message to this closed TCP socket, it will not be delivered because the remote end is gone. This particular issue is similar to the issue outlined here: https://github.com/golang/go/issues/10940

I've occasionally seen this second message be delivered after restarting Heka but I have not been able to consistently reproduce that behavior.

With this PR, you can enable 'close_after_write' on the TcpOutput plugin which closes the socket and avoids this CLOSE_WAIT issue.