### PR TITLE
Delay startup when buffered plugin has full buffer to give time

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,7 +20,6 @@ Features
 * Adder `log_flags` to hekad config, to control the prefix for STDOUT and
   STDERR logs.
 
-
 Bug Handling
 ------------
 
@@ -61,6 +60,9 @@ Bug Handling
 
 * Fixed panic that was occurring when loading a config file or directory that
   exists but which registers no plugins (#1597).
+
+* Delay start up when a buffered plugin's buffer is at capacity to give the
+  back-pressure time to resolve (#1738).
 
 * Fixed bug where LogStreamerInput would sometimes loop infinitely reading the
   same file over and over when reading gzipped log files.

--- a/cmd/hekad/config.go
+++ b/cmd/hekad/config.go
@@ -47,6 +47,7 @@ type HekadConfig struct {
 	Hostname              string
 	MaxMessageSize        uint32 `toml:"max_message_size"`
 	LogFlags              int    `toml:"log_flags"`
+	FullBufferMaxRetries  uint32 `toml:"full_buffer_max_retries"`
 }
 
 func LoadHekadConfig(configPath string) (config *HekadConfig, err error) {
@@ -71,6 +72,7 @@ func LoadHekadConfig(configPath string) (config *HekadConfig, err error) {
 		PidFile:               "",
 		Hostname:              hostname,
 		LogFlags:              log.LstdFlags,
+		FullBufferMaxRetries:  10,
 	}
 
 	var configFile map[string]toml.Primitive

--- a/cmd/hekad/main.go
+++ b/cmd/hekad/main.go
@@ -87,6 +87,7 @@ func setGlobalConfigs(config *HekadConfig) (*pipeline.GlobalConfigStruct, string
 	globals.ShareDir = config.ShareDir
 	globals.SampleDenominator = config.SampleDenominator
 	globals.Hostname = config.Hostname
+	globals.FullBufferMaxRetries = uint(config.FullBufferMaxRetries)
 
 	return globals, cpuProfName, memProfName
 }

--- a/docs/source/config/index.rst
+++ b/docs/source/config/index.rst
@@ -171,6 +171,14 @@ Config:
     and time, the default) or 0 (no prefix). See
     `https://golang.org/pkg/log/#pkg-constants Go documentation`_ for details.
 
+- full_buffer_max_retries (int):
+    When Heka shuts down due to a buffer filling to capacity, the next time
+    Heka starts it will delay startup briefly to give the buffer a chance to
+    drain, to alleviate the back-pressure. This setting specifies the maximum
+    number of intervals (max 1s in duration) Heka should wait for the buffer
+    size to get below 90% of capacity before deciding that the issue is not
+    resolved and continuing startup (or shutting down).
+
 Example hekad.toml file
 =======================
 

--- a/pipeline/router.go
+++ b/pipeline/router.go
@@ -366,7 +366,7 @@ func (mr *MatchRunner) deliver(pack *PipelinePack) error {
 		if err == QueueIsFull {
 			switch mr.bufFeeder.Config.FullAction {
 			case "shutdown":
-				mr.globals.ShutDown()
+				mr.globals.ShutDown(1)
 			case "block":
 				for {
 					err = mr.bufFeeder.QueueRecord(pack)

--- a/sandbox/plugins/sandbox_decoder.go
+++ b/sandbox/plugins/sandbox_decoder.go
@@ -169,7 +169,7 @@ func (s *SandboxDecoder) SetDecoderRunner(dr pipeline.DecoderRunner) {
 			s.sb.Destroy("")
 			s.sb = nil
 		}
-		s.pConfig.Globals.ShutDown()
+		s.pConfig.Globals.ShutDown(1)
 		return
 	}
 
@@ -306,7 +306,7 @@ func (s *SandboxDecoder) Decode(pack *pipeline.PipelinePack) (packs []*pipeline.
 	if retval > 0 {
 		err = fmt.Errorf("FATAL: %s", s.sb.LastError())
 		s.dRunner.LogError(err)
-		s.pConfig.Globals.ShutDown()
+		s.pConfig.Globals.ShutDown(1)
 	}
 	if retval < 0 {
 		atomic.AddInt64(&s.processMessageFailures, 1)


### PR DESCRIPTION
for back-pressure to be relieved, add `full_buffer_max_retries`
global config setting, exit w/ non-zero exit code on error cases.