### PR TITLE
Bugfix/elasticsearch output

### DIFF
--- a/plugins/elasticsearch/elasticsearch.go
+++ b/plugins/elasticsearch/elasticsearch.go
@@ -381,6 +381,10 @@ func (h *HttpBulkIndexer) Index(body []byte) (err error, retry bool) {
 	var response_body []byte
 	var response_body_json map[string]interface{}
 
+	if len(body) == 0 {
+		return nil, false
+	}
+
 	url := fmt.Sprintf("%s://%s%s%s", h.Protocol, h.Domain, h.Path, "/_bulk")
 
 	// Creating ElasticSearch Bulk HTTP request

--- a/plugins/elasticsearch/elasticsearch.go
+++ b/plugins/elasticsearch/elasticsearch.go
@@ -426,7 +426,7 @@ func (h *HttpBulkIndexer) Index(body []byte) (err error, retry bool) {
 				response.Status, string(response_body)), true
 		}
 		json_errors, ok := response_body_json["errors"].(bool)
-		if ok && json_errors {
+		if ok && json_errors && response.StatusCode != 200 {
 			return fmt.Errorf(
 				"ElasticSearch server reported error within JSON. Status: %s. Body: %s",
 				response.Status, string(response_body)), false

--- a/plugins/elasticsearch/elasticsearch.go
+++ b/plugins/elasticsearch/elasticsearch.go
@@ -41,6 +41,11 @@ type ESBatch struct {
 	batch       []byte
 }
 
+type MsgPack struct {
+	bytes       []byte
+	queueCursor string
+}
+
 // Output plugin that index messages to an elasticsearch cluster.
 // Largely based on FileOutput plugin.
 type ElasticSearchOutput struct {
@@ -48,6 +53,7 @@ type ElasticSearchOutput struct {
 	dropMessageCount int64
 	count            int64
 	backChan         chan []byte
+	recvChan         chan *MsgPack
 	batchChan        chan ESBatch // Chan to pass completed batches
 	outBatch         []byte
 	queueCursor      string
@@ -59,7 +65,6 @@ type ElasticSearchOutput struct {
 	reportLock       sync.Mutex
 	stopChan         chan bool
 	flushTicker      *time.Ticker
-	flushManual      chan struct{}
 }
 
 // ConfigStruct for ElasticSearchOutput plugin.
@@ -118,7 +123,7 @@ func (o *ElasticSearchOutput) Init(config interface{}) (err error) {
 
 	o.batchChan = make(chan ESBatch)
 	o.backChan = make(chan []byte, 2)
-	o.flushManual = make(chan struct{})
+	o.recvChan = make(chan *MsgPack, 1024)
 
 	var serverUrl *url.URL
 	if serverUrl, err = url.Parse(o.conf.Server); err == nil {
@@ -185,14 +190,9 @@ func (o *ElasticSearchOutput) ProcessMessage(pack *PipelinePack) error {
 	}
 
 	if outBytes != nil {
-		o.outBatch = append(o.outBatch, outBytes...)
-		o.queueCursor = pack.QueueCursor
-		o.count++
-		if len(o.outBatch) > 0 && o.bulkIndexer.CheckFlush(int(o.count), len(o.outBatch)) {
-			o.flushManual <- struct{}{}
-			<-o.flushManual // block until the batch is sent.
-		}
+		o.recvChan <- &MsgPack{bytes: outBytes, queueCursor: pack.QueueCursor}
 	}
+
 	return nil
 }
 
@@ -203,9 +203,13 @@ func (o *ElasticSearchOutput) batchSender() {
 		case <-o.stopChan:
 			ok = false
 			continue
-		case <-o.flushManual:
-			o.sendBatch()
-			o.flushManual <- struct{}{}
+		case pack := <-o.recvChan:
+			o.outBatch = append(o.outBatch, pack.bytes...)
+			o.queueCursor = pack.queueCursor
+			o.count++
+			if len(o.outBatch) > 0 && o.bulkIndexer.CheckFlush(int(o.count), len(o.outBatch)) {
+				o.sendBatch()
+			}
 		case <-o.flushTicker.C:
 			if len(o.outBatch) > 0 {
 				o.sendBatch()


### PR DESCRIPTION
- Bugfix: The `ProcessMessage` function in the ES plugin is not synchronized (the `append` function is not thread safe) when goroutines running in parallel.
- Bugfix: Should Drop empty batch instead of sending it to ES (ES will respond 400).
- Enhancement: Only log error message when ES's resonpse code != 200.

 But I didn't find the source code that makes `ProcessMessage` function run in multiple goroutines?