### PR TITLE
Fix ESJsonEncoder bug causing invalid output

### DIFF
--- a/plugins/elasticsearch/encoders.go
+++ b/plugins/elasticsearch/encoders.go
@@ -344,9 +344,10 @@ func (e *ESJsonEncoder) Encode(pack *PipelinePack) (output []byte, err error) {
 	e.coord.PopulateBuffer(pack.Message, &buf)
 	buf.WriteByte(NEWLINE)
 	buf.WriteString(`{`)
-	first := true
+	bufLenBeforeFirstField := buf.Len()
 
 	for _, f := range e.fields {
+		first := buf.Len() == bufLenBeforeFirstField
 		switch strings.ToLower(f) {
 		case "uuid":
 			writeStringField(first, &buf, e.fieldMappings.Uuid, m.GetUuidString())
@@ -392,14 +393,12 @@ func (e *ESJsonEncoder) Encode(pack *PipelinePack) (output []byte, err error) {
 						}
 					}
 					writeField(first, &buf, field, raw)
-					first = false
 				}
 			}
 		default:
 			err = fmt.Errorf("Unable to find field: %s", f)
 			return
 		}
-		first = false
 	}
 
 	buf.WriteString(`}`)

--- a/plugins/elasticsearch/encoders_test.go
+++ b/plugins/elasticsearch/encoders_test.go
@@ -379,6 +379,31 @@ func ESEncodersSpec(c gs.Context) {
 			c.Expect(decoded["test_raw_field_bytes_array"].([]interface{})[1].(map[string]interface{})["jkl;"], gs.Equals, 123.0)
 		})
 
+		c.Specify("Produces valid JSON when DynamicFields is first configured field and message has no fields", func() {
+			config := encoder.ConfigStruct().(*ESJsonEncoderConfig)
+			config.Fields = []string{"DynamicFields", "Hostname"}
+			err := encoder.Init(config)
+			c.Assume(err, gs.IsNil)
+
+			msg := getTestMessageWithFunnyFields()
+			msg.Fields = nil
+			pack := NewPipelinePack(recycleChan)
+			pack.Message = msg
+			b, err := encoder.Encode(pack)
+			c.Assume(err, gs.IsNil)
+
+			output := string(b)
+			lines := strings.Split(output, string(NEWLINE))
+
+			decoded := make(map[string]interface{})
+			err = json.Unmarshal([]byte(lines[0]), &decoded)
+			c.Expect(err, gs.IsNil)
+
+			decoded = make(map[string]interface{})
+			err = json.Unmarshal([]byte(lines[1]), &decoded)
+			c.Expect(err, gs.IsNil)
+		})
+
 		c.Specify("Should use field mappings", func() {
 			config := encoder.ConfigStruct().(*ESJsonEncoderConfig)
 			config.FieldMappings = &ESFieldMappings{


### PR DESCRIPTION
ESJsonEncoder emits invalid JSON for messages without fields if its
"fields" configuration parameter begins with DynamicFields and contains
at least one other field. In this situation, the second line of output
will begin with '{,'.

This change fixes the problem by altering how ESJsonEncoder.Encode()
decides if it has written any fields.