### PR TITLE
Implementation of a multiline splitter

### DIFF
--- a/docs/source/config/splitters/index_noref.rst
+++ b/docs/source/config/splitters/index_noref.rst
@@ -20,3 +20,6 @@ Splitters
 
 .. include:: /config/splitters/token.rst
    :start-line: 1
+
+.. include:: /config/splitters/pattern_grouping.rst
+   :start-line: 1

--- a/docs/source/config/splitters/pattern_grouping.rst
+++ b/docs/source/config/splitters/pattern_grouping.rst
@@ -1,0 +1,63 @@
+.. _config_pattern_grouping_splitter:
+
+PatternGrouping Splitter
+==============
+
+Plugin Name: **PatternGroupingSplitter**
+
+A PatternGroupingSplitter is an extension of the RegexSplitter for use cases
+where a single log record may sometimes span multiple delimiter patterns. The
+delimiter pattern is first used to break the stream into records as it is in
+the RegexSplitter. But then a second pass is taken over the split records and
+the grouping pattern is used to rejoin matching, contiguous records into a
+single record.
+
+This splitter is useful for things like Stacktraces intermixed with other logs
+in the same stream. The normal record delimiter pattern might be a line feed
+and so the first pass by the splitter splits the stream into lines. In the
+second pass, the grouping pattern is used to identify the lines of a stacktrace
+that should be grouped back together to keep the trace in a single log record.
+In this way you can get a single record for each stacktrace, but all other
+lines are split and recorded separately.
+
+Another example use case is where an application dumps configuration values to
+the log on a timed basis and these values should all be grouped into a single
+record, rather than one line at a time.
+
+The performance characteristics of the PatternGroupingSplitter are noticeably
+worse than a RegexSplitter. The RegexSplitter is optimized to break one record
+off at a time, matching only the first occurrence of the record delimiter before
+processing the record. The PatternGroupingSplitter must break apart all of the
+records in a single read from the stream, then re-test each line against the
+grouping pattern. This can result in the same line being processed by the
+delimiter pattern many times. Careful consideration should be made as to
+whether or not this performance tradeoff is tolerable.
+
+Finally, the PatternGroupingSplitter, unlike the RegexSplitter, will always
+include the delimiter pattern for each line and also at the end of the record.
+
+Config:
+
+- delimiter (string)
+	Regular expression to be used as the record boundary. May contain zero or
+	one specified capture groups.
+- grouping (string)
+	Regular expression to be used to regroup matching records into a single
+	final record. Any contiguous lines matching this expression will become
+	a single record.
+- max_lines (int)
+    The maximum number of records to process in a single splitting operation
+	with the delimiter pattern. This is used to tune for performance by
+	helping to limit the number of times a single line will be re-parsed
+	with the delimiter expression. The knock-on effect is that this will also
+	set the upper bound on the number of lines that can be grouped into a
+	single record. Defaults to 99.
+
+Example:
+
+.. code-block:: ini
+
+	[stacktrace_grouping_splitter]
+	type = "PatternGroupingSplitter"
+	delimiter = '\n'
+	grouping = '(\] FATAL )|(\A\s*.+Exception: .)|(at \S+\(\S+\))|(\A\s+... \d+ more)|(\A\s*Caused by:.)|(\A\s*Grave:)'

--- a/pipeline/all_specs_test.go
+++ b/pipeline/all_specs_test.go
@@ -43,6 +43,7 @@ func TestAllSpecs(t *testing.T) {
 	r.AddSpec(OutputRunnerSpec)
 	r.AddSpec(ProtobufDecoderSpec)
 	r.AddSpec(QueueBufferSpec)
+	r.AddSpec(MultilineSpec)
 	r.AddSpec(RegexSpec)
 	r.AddSpec(ReportSpec)
 	r.AddSpec(SplitterRunnerSpec)

--- a/pipeline/all_specs_test.go
+++ b/pipeline/all_specs_test.go
@@ -43,7 +43,7 @@ func TestAllSpecs(t *testing.T) {
 	r.AddSpec(OutputRunnerSpec)
 	r.AddSpec(ProtobufDecoderSpec)
 	r.AddSpec(QueueBufferSpec)
-	r.AddSpec(MultilineSpec)
+	r.AddSpec(PatternGroupingSpec)
 	r.AddSpec(RegexSpec)
 	r.AddSpec(ReportSpec)
 	r.AddSpec(SplitterRunnerSpec)

--- a/pipeline/config.go
+++ b/pipeline/config.go
@@ -574,6 +574,7 @@ func makeDefaultConfigs() map[string]bool {
 		"ProtobufDecoder":     false,
 		"ProtobufEncoder":     false,
 		"TokenSplitter":       false,
+		"MultilineSplitter":   false,
 		"HekaFramingSplitter": false,
 		"NullSplitter":        false,
 	}

--- a/pipeline/config.go
+++ b/pipeline/config.go
@@ -574,7 +574,7 @@ func makeDefaultConfigs() map[string]bool {
 		"ProtobufDecoder":     false,
 		"ProtobufEncoder":     false,
 		"TokenSplitter":       false,
-		"MultilineSplitter":   false,
+		"PatternGroupingSplitter":   false,
 		"HekaFramingSplitter": false,
 		"NullSplitter":        false,
 	}

--- a/pipeline/splitters.go
+++ b/pipeline/splitters.go
@@ -149,6 +149,15 @@ func (r *MultilineSplitter) FindRecord(buf []byte) (bytesRead int, record []byte
 		return bytesRead, buf[:bytesRead]
 	}
 
+	if len(loc) == 1 {
+		// In this scenario we are on a multiline but missed the full record in this
+		// read, so we just emit what we have. It would be nice to just try this again on
+		// next read but without keeping more state, we could try forever if somehow that
+		// next line never comes (i.e. truncated input).
+		bytesRead = loc[0][1]
+		return bytesRead, buf[:bytesRead]
+	}
+
 	// Loop through, looking for the first delimiter not also matching a multiline
 	var lastDelimiter []int
 	previous := []int{ 0, 0 }

--- a/pipeline/splitters_test.go
+++ b/pipeline/splitters_test.go
@@ -156,6 +156,93 @@ func TokenSpec(c gs.Context) {
 	})
 }
 
+func MultilineSpec(c gs.Context) {
+	c.Specify("A MultilineSplitter", func() {
+		splitter := &MultilineSplitter{}
+		config := splitter.ConfigStruct().(*MultilineSplitterConfig)
+		config.Delimiter = "\n"
+		config.Multiline = "(\\A\\s*.+Exception: .)|(at \\S+\\(\\S+\\))|(\\A\\s+... \\d+ more)|(\\A\\s*Caused by:.)|(\\A\\s*Grave:)"
+		sRunner := makeSplitterRunner("MultilineSplitter", splitter)
+
+		c.Specify("handles empty lines", func() {
+			buf := []byte("\n\n")
+			reader := bytes.NewReader(buf)
+			err := splitter.Init(config)
+			c.Assume(err, gs.IsNil)
+
+			n, record, err := sRunner.GetRecordFromStream(reader)
+			c.Expect(n, gs.Equals, 1)
+			c.Expect(err, gs.IsNil)
+			c.Expect(string(record), gs.Equals, "\n")
+
+			n, record, err = sRunner.GetRecordFromStream(reader)
+			c.Expect(n, gs.Equals, 1)
+			c.Expect(err, gs.IsNil)
+			c.Expect(string(record), gs.Equals, "\n")
+		})
+
+		c.Specify("correctly identifies multiline grouping for simple traces", func() {
+			buf := []byte("java.io.FileNotFoundException: fred.txt\n\tat java.io.FileInputStream.<init>(FileInputStream.java)\n\tat java.io.FileInputStream.<init>(FileInputStream.java)\n\tat ExTest.readMyFile(ExTest.java:19)\n\tat ExTest.main(ExTest.java:7)\n\nDon't capture me\nMore")
+			reader := bytes.NewReader(buf)
+			err := splitter.Init(config)
+			c.Assume(err, gs.IsNil)
+
+			n, record, err := sRunner.GetRecordFromStream(reader)
+			c.Expect(n, gs.Equals, 223)
+			c.Expect(err, gs.IsNil)
+			c.Expect(string(record), gs.Equals, "java.io.FileNotFoundException: fred.txt\n\tat java.io.FileInputStream.<init>(FileInputStream.java)\n\tat java.io.FileInputStream.<init>(FileInputStream.java)\n\tat ExTest.readMyFile(ExTest.java:19)\n\tat ExTest.main(ExTest.java:7)\n")
+		})
+
+		c.Specify("correctly identifies multiline grouping for complex traces", func() {
+			buf := []byte("\n\njuil. 25, 2012 10:49:46 AM hudson.triggers.SafeTimerTask run\nGrave: Timer task com.base2services.jenkins.SqsQueueHandler@32eea79d failed\n\tcom.amazonaws.AmazonClientException: Unable to calculate a request signature: Unable to calculate a request signature: Empty key\n\tat com.amazonaws.auth.AbstractAWSSigner.signAndBase64Encode(AbstractAWSSigner.java:71)\n\tat com.amazonaws.auth.AbstractAWSSigner.signAndBase64Encode(AbstractAWSSigner.java:55)\n\tat com.amazonaws.auth.QueryStringSigner.sign(QueryStringSigner.java:83)\nCaused by: com.amazonaws.AmazonClientException: Unable to calculate a request signature: Empty key\npartial")
+			reader := bytes.NewReader(buf)
+			err := splitter.Init(config)
+			c.Assume(err, gs.IsNil)
+
+			n, record, err := sRunner.GetRecordFromStream(reader)
+			n, record, err = sRunner.GetRecordFromStream(reader)
+
+			n, record, err = sRunner.GetRecordFromStream(reader)
+			c.Expect(n, gs.Equals, 61)
+			c.Expect(err, gs.IsNil)
+			c.Expect(string(record), gs.Equals, "juil. 25, 2012 10:49:46 AM hudson.triggers.SafeTimerTask run\n")
+
+			n, record, err = sRunner.GetRecordFromStream(reader)
+			c.Expect(n, gs.Equals, 554)
+			c.Expect(err, gs.IsNil)
+			c.Expect(string(record), gs.Equals, "Grave: Timer task com.base2services.jenkins.SqsQueueHandler@32eea79d failed\n\tcom.amazonaws.AmazonClientException: Unable to calculate a request signature: Unable to calculate a request signature: Empty key\n\tat com.amazonaws.auth.AbstractAWSSigner.signAndBase64Encode(AbstractAWSSigner.java:71)\n\tat com.amazonaws.auth.AbstractAWSSigner.signAndBase64Encode(AbstractAWSSigner.java:55)\n\tat com.amazonaws.auth.QueryStringSigner.sign(QueryStringSigner.java:83)\nCaused by: com.amazonaws.AmazonClientException: Unable to calculate a request signature: Empty key\n")
+
+			// We don't want to ever get back the partial match
+			n, record, err = sRunner.GetRecordFromStream(reader)
+			c.Expect(n, gs.Equals, 0)
+			c.Expect(err, gs.IsNil)
+			c.Expect(string(record), gs.Equals, "")
+		})
+
+		c.Specify("doesn't interfere with non-multiline splitting", func() {
+			buf := []byte("test1\ntest2\npartial")
+			reader := bytes.NewReader(buf)
+			err := splitter.Init(config)
+			c.Assume(err, gs.IsNil)
+
+			n, record, err := sRunner.GetRecordFromStream(reader)
+			c.Expect(n, gs.Equals, 6)
+			c.Expect(err, gs.IsNil)
+			c.Expect(string(record), gs.Equals, "test1\n")
+
+			n, record, err = sRunner.GetRecordFromStream(reader)
+			c.Expect(n, gs.Equals, 6)
+			c.Expect(err, gs.IsNil)
+			c.Expect(string(record), gs.Equals, "test2\n")
+
+			n, record, err = sRunner.GetRecordFromStream(reader)
+			c.Expect(n, gs.Equals, 0)
+			c.Expect(err, gs.IsNil)
+			c.Expect(string(record), gs.Equals, "")
+		})
+	})
+}
+
 func RegexSpec(c gs.Context) {
 	c.Specify("A RegexSplitter", func() {
 		splitter := &RegexSplitter{}

--- a/pipeline/splitters_test.go
+++ b/pipeline/splitters_test.go
@@ -156,13 +156,13 @@ func TokenSpec(c gs.Context) {
 	})
 }
 
-func MultilineSpec(c gs.Context) {
-	c.Specify("A MultilineSplitter", func() {
-		splitter := &MultilineSplitter{}
-		config := splitter.ConfigStruct().(*MultilineSplitterConfig)
+func PatternGroupingSpec(c gs.Context) {
+	c.Specify("A PatternGroupingSplitter", func() {
+		splitter := &PatternGroupingSplitter{}
+		config := splitter.ConfigStruct().(*PatternGroupingSplitterConfig)
 		config.Delimiter = "\n"
-		config.Multiline = "(\\A\\s*.+Exception: .)|(at \\S+\\(\\S+\\))|(\\A\\s+... \\d+ more)|(\\A\\s*Caused by:.)|(\\A\\s*Grave:)"
-		sRunner := makeSplitterRunner("MultilineSplitter", splitter)
+		config.Grouping = "(\\A\\s*.+Exception: .)|(at \\S+\\(\\S+\\))|(\\A\\s+... \\d+ more)|(\\A\\s*Caused by:.)|(\\A\\s*Grave:)"
+		sRunner := makeSplitterRunner("PatternGroupingSplitter", splitter)
 
 		c.Specify("handles empty lines", func() {
 			buf := []byte("\n\n")


### PR DESCRIPTION
We work with a lot of Java and Scala stacktraces and the other options I've tried for supporting them in Heka don't work as well as I'd like. This is an implementation of a regex-based `MultilineSplitter` which works great for our stacktraces. The implementation is that you define a regex to use as the delimiter and a regex used to match lines that should be joined together. It first splits the buffer using the delimiter and then checks each section against the multiline regex to see if it's a match. All lines that are contiguous and match the multiline regex are joined. Because of the multiline nature, it always keeps the delimiter on the EOL.

This is going to be notably slower than the `RegexSplitter` because it has to find many matches on the first pass rather than the first one. (That's limited to 99 by default and is not currently configurable without a recompile.) Secondly, it will run a second regex on all those matches. Given's Go's performance-oriented Regex implementation and reasonable logging levels it appears to be tolerable. It can, in the worst case, re-split the first lines in a very large buffer repeatedly.

Here's an example configuration for the splitter:
```toml
[multiline_splitter]
type = "MultilineSplitter"
multiline = '(\] FATAL )|(\A\s*.+Exception: .)|(at \S+\(\S+\))|(\A\s+... \d+ more)|(\A\s*Caused by:.)|(\A\s*Grave:)'
delimiter = '\n'
```
Given a broken Kafka installation, this generates something like the following when encoded with the `ESLogstashV0Encoder`:
```json
{
  "@fields": {
    "ContainerName": "boring_bohr",
    "ContainerID": "910f097243d6"
  },
  "@source_host": "docker1",
  "@uuid": "bda1cb47-8aa4-420e-9316-543364afd5fc",
  "@timestamp": "2016-01-24T14:22:17",
  "@type": "message",
  "@logger": "stdout",
  "@severity": 7,
  "@message": "java.net.ConnectException: Connection refused\n\tat sun.nio.ch.SocketChannelImpl.checkConnect(Native Method)\n\tat sun.nio.ch.SocketChannelImpl.finishConnect(SocketChannelImpl.java:716)\n\tat org.apache.zookeeper.ClientCnxnSocketNIO.doTransport(ClientCnxnSocketNIO.java:361)\n\tat org.apache.zookeeper.ClientCnxn$SendThread.run(ClientCnxn.java:1081)\n",
  "@envversion": "",
  "@pid": 0
}
```
Note that this output is from a splitter-enabled Docker input plugin that I will prepare a separate PR for.