### PR TITLE
A major revamp of the DockerLogInput plugin

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,11 @@ Bug Handling
 * Updated Sarama dependency from pre-1.0 release fork to fork (with only test
   code changes) of Sarama 1.5.0 release.
 
+* Fixed bug where DockerLogInput would not reconnect to a Docker daemon that
+  had been down for some time (#1843).
+
+* More verbose logging from the DockerLogInput plugin (#1843).
+
 Features
 --------
 
@@ -22,6 +27,10 @@ Features
   their original import paths.
 
 * Added `initial_tail` config option to LogstreamerInput (#1482, #1801).
+
+* Added Splitter support to DockerLogInput plugin (#1843).
+
+* Added `fields_from_labels` config option to DockerLogInput (#1843).
 
 0.10.1 (2016-??-??)
 ===================

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,8 +12,8 @@ Bug Handling
 * Updated Sarama dependency from pre-1.0 release fork to fork (with only test
   code changes) of Sarama 1.5.0 release.
 
-* Fixed bug where DockerLogInput would not reconnect to a Docker daemon that
-  had been down for some time (#1843).
+* Fixed bug where DockerLogInput would not reconnect when a Docker daemon 
+  was down for some time (#1843).
 
 * More verbose logging from the DockerLogInput plugin (#1843).
 

--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -175,7 +175,7 @@ if (INCLUDE_GEOIP)
 endif()
 
 if (INCLUDE_DOCKER_PLUGINS)
-    git_clone(https://github.com/carlanton/go-dockerclient d408f209d5946d86da69382b3eb0a6faac7b3885)
+    git_clone(https://github.com/fsouza/go-dockerclient 175e1df973274f04e9b459a62cffc49808f1a649)
 endif()
 
 if (INCLUDE_MOZSVC)

--- a/plugins/docker/attacher.go
+++ b/plugins/docker/attacher.go
@@ -134,6 +134,8 @@ func (m *AttachManager) attachAll() error {
 		}
 	}
 
+	m.ir.LogMessage("Attached to all containers")
+
 	return nil
 }
 
@@ -152,8 +154,6 @@ func (m *AttachManager) Run(ir InputRunner, hostname string, stopChan chan error
 		)
 		return err
 	}
-
-	m.ir.LogMessage("Attached to all containers")
 
 	err = withRetries(func() error { return m.client.AddEventListener(m.events) })
 	if err != nil {

--- a/plugins/docker/client.go
+++ b/plugins/docker/client.go
@@ -1,6 +1,6 @@
 package docker
 
-import "github.com/carlanton/go-dockerclient"
+import "github.com/fsouza/go-dockerclient"
 
 type DockerClient interface {
 	// AddEventListener adds a new listener to container events in the Docker
@@ -8,6 +8,9 @@ type DockerClient interface {
 	//
 	// The parameter is a channel through which events will be sent.
 	AddEventListener(listener chan<- *docker.APIEvents) error
+
+	// RemoveEventListener removes a listener from the monitor.
+	RemoveEventListener(listener chan *docker.APIEvents) error
 
 	// ListContainersOptions specify parameters to the ListContainers function.
 	//
@@ -23,4 +26,9 @@ type DockerClient interface {
 	//
 	// See http://goo.gl/RRAhws for more details.
 	AttachToContainer(opts docker.AttachToContainerOptions) error
+
+	// Ping pings the docker server
+	//
+	// See https://goo.gl/kQCfJj for more details.
+	Ping() error
 }

--- a/plugins/docker/docker_event.go
+++ b/plugins/docker/docker_event.go
@@ -2,10 +2,9 @@ package docker
 
 import (
 	"fmt"
-	"path/filepath"
 	"time"
 
-	"github.com/carlanton/go-dockerclient"
+	"github.com/fsouza/go-dockerclient"
 	"github.com/mozilla-services/heka/message"
 	"github.com/mozilla-services/heka/pipeline"
 	"github.com/pborman/uuid"
@@ -18,7 +17,7 @@ type DockerEventInputConfig struct {
 
 type DockerEventInput struct {
 	conf         *DockerEventInputConfig
-	dockerClient *docker.Client
+	dockerClient DockerClient
 	eventStream  chan *docker.APIEvents
 	stopChan     chan error
 }
@@ -28,25 +27,6 @@ func (dei *DockerEventInput) ConfigStruct() interface{} {
 		Endpoint: "unix:///var/run/docker.sock",
 		CertPath: "",
 	}
-}
-
-func newDockerClient(endpoint string, certpath string) (*docker.Client, error) {
-	var client *docker.Client
-	var err error
-	if certpath == "" {
-		client, err = docker.NewClient(endpoint)
-	} else {
-		key := filepath.Join(certpath, "key.pem")
-		ca := filepath.Join(certpath, "ca.pem")
-		cert := filepath.Join(certpath, "cert.pem")
-		client, err = docker.NewTLSClient(endpoint, cert, key, ca)
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	return client, nil
 }
 
 func (dei *DockerEventInput) Init(config interface{}) error {


### PR DESCRIPTION
This PR is a general cleanup of the Docker input plugin to accomplish three major goals:

1. Don't lose connections to Docker when the daemon is down for a period of time
2. Support the splitter API in this plugin
3. Log what is happening

From running Heka with Docker for quite some time at my previous employer (New Relic) we saw that Heka would lose connections to the Docker daemon if it was down for a period of time (e.g. not a restart but a full stop for minute). This was because the re-connect strategy was to restart the plugin entirely and Heka would give up doing that after a short time. This pR takes a different approach and tries very hard to stay connected to the Docker daemon while also still exiting the plugin on total failure.

Secondly a major drawback of the existing plugin is that lack of support for the new splitters means that you are stuck with with-by-line output from this Input. This PR supports splitters in the `DockerLogInput` plugin. At Nitro we're now using this with our `MultilineSplitter` implementation in #1842 to grab stacktraces that are output from apps running under Docker.

Finally, without logging, it's really hard to tell what the plugin is seeing an not seeing. This adds some minimalist logging that seems to be enough to tell when things are attached properly or not.