### PR TITLE
Add TLS configuration to KafkaInput/KafkaOutput.

### DIFF
--- a/docs/source/config/inputs/kafka.rst
+++ b/docs/source/config/inputs/kafka.rst
@@ -77,6 +77,18 @@ Config:
     client code consumes events, greatly improving throughput. The default is
     16.
 
+.. versionadded:: 0.11
+
+- use_tls (bool, optional):
+    Specifies whether or not SSL/TLS encryption should be used for the TCP
+    connections. Defaults to false.
+
+- tls (TlsConfig, optional):
+    A sub-section that specifies the settings to be used for any SSL/TLS
+    encryption. This will only have any impact if ``use_tls`` is set to true.
+    See :ref:`tls`.
+
+
 Example 1: Read Fxa messages from partition 0.
 
 .. code-block:: ini

--- a/docs/source/config/outputs/kafka.rst
+++ b/docs/source/config/outputs/kafka.rst
@@ -80,6 +80,17 @@ Config:
     MaxRequestSize (100 MiB). Default is 50 * 1024 * 1024 (50 MiB), cannot be
     more than (MaxRequestSize - 10 KiB).
 
+.. versionadded:: 0.11
+
+- use_tls (bool, optional):
+    Specifies whether or not SSL/TLS encryption should be used for the TCP
+    connections. Defaults to false.
+
+- tls (TlsConfig, optional):
+    A sub-section that specifies the settings to be used for any SSL/TLS
+    encryption. This will only have any impact if ``use_tls`` is set to true.
+    See :ref:`tls`.
+
 Example (send various Fxa messages to a static Fxa topic):
 
 .. code-block:: ini

--- a/plugins/kafka/kafka_input.go
+++ b/plugins/kafka/kafka_input.go
@@ -10,6 +10,7 @@
 # Contributor(s):
 #   Mike Trinkala (trink@mozilla.com)
 #   Rob Miller (rmiller@mozilla.com)
+#   Matt Moyer (moyer@simple.com)
 #
 # ***** END LICENSE BLOCK *****/
 
@@ -27,6 +28,7 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/mozilla-services/heka/message"
 	"github.com/mozilla-services/heka/pipeline"
+	"github.com/mozilla-services/heka/plugins/tcp"
 )
 
 type KafkaInputConfig struct {
@@ -38,6 +40,10 @@ type KafkaInputConfig struct {
 	MetadataRetries            int    `toml:"metadata_retries"`
 	WaitForElection            uint32 `toml:"wait_for_election"`
 	BackgroundRefreshFrequency uint32 `toml:"background_refresh_frequency"`
+
+	// TLS Config
+	UseTls bool `toml:"use_tls"`
+	Tls    tcp.TlsConfig
 
 	// Broker Config
 	MaxOpenRequests int    `toml:"max_open_reqests"`
@@ -145,6 +151,13 @@ func (k *KafkaInput) Init(config interface{}) (err error) {
 	k.saramaConfig.Metadata.Retry.Max = k.config.MetadataRetries
 	k.saramaConfig.Metadata.Retry.Backoff = time.Duration(k.config.WaitForElection) * time.Millisecond
 	k.saramaConfig.Metadata.RefreshFrequency = time.Duration(k.config.BackgroundRefreshFrequency) * time.Millisecond
+
+	k.saramaConfig.Net.TLS.Enable = k.config.UseTls
+	if k.config.UseTls {
+		if k.saramaConfig.Net.TLS.Config, err = tcp.CreateGoTlsConfig(&k.config.Tls); err != nil {
+			return fmt.Errorf("TLS init error: %s", err)
+		}
+	}
 
 	k.saramaConfig.Net.MaxOpenRequests = k.config.MaxOpenRequests
 	k.saramaConfig.Net.DialTimeout = time.Duration(k.config.DialTimeout) * time.Millisecond


### PR DESCRIPTION
This allows `KafkaInput` and `KafkaOutput` to connect to the Kafka brokers over a secure connection. The [server side support](http://kafka.apache.org/documentation.html#security_ssl) for this functionality was recently added in Kafka 0.9.0.0.

I structured the configuration identically to the `TcpOutput` parameters and (speculatively) tagged it as appearing in 0.11.