### PR TITLE
Log decode failures by default

### DIFF
--- a/pipeline/plugin_maker.go
+++ b/pipeline/plugin_maker.go
@@ -119,8 +119,10 @@ func (m *pluginMaker) OrigPrepCommonTypedConfig() (interface{}, error) {
 	)
 	switch m.category {
 	case "Input":
+		b := true
 		commonInput := CommonInputConfig{
 			Retries: getDefaultRetryOptions(),
+			LogDecodeFailures: &b,
 		}
 		err = toml.PrimitiveDecode(m.tomlSection, &commonInput)
 		commonTypedConfig = commonInput


### PR DESCRIPTION
This brings the code in line with the documentation changes made in bb7e83d3.
