### PR TITLE
Add check_data_interval option for the LogStreamer input

### DIFF
--- a/docs/source/config/inputs/logstreamer.rst
+++ b/docs/source/config/inputs/logstreamer.rst
@@ -59,3 +59,10 @@ Config:
 - splitter (string, optional):
     Defaults to "TokenSplitter", which will split the log stream into one
     Heka message per line.
+
+.. versionadded:: 0.10
+
+- check_data_interval (string)
+    A time duration string. This interval is how often streams will be checked
+    for new data. Defaults to "250ms". If the plugin processes many logstreams,
+    you may increase this value to reduce the CPU load.

--- a/plugins/logstreamer/logstreamer_input.go
+++ b/plugins/logstreamer/logstreamer_input.go
@@ -49,6 +49,9 @@ type LogstreamerInputConfig struct {
 	// Rescan interval declares how often the full directory scanner
 	// runs to locate more logfiles/streams
 	RescanInterval string `toml:"rescan_interval"`
+	// Check data interval declares how often the plugin checks if more data is
+	// available from the logfiles/streams
+	CheckDataInterval string `toml:"check_data_interval"`
 	// So we can default to TokenSplitter.
 	Splitter string
 }
@@ -58,6 +61,7 @@ type LogstreamerInput struct {
 	logstreamSet       *ls.LogstreamSet
 	logstreamSetLock   sync.RWMutex
 	rescanInterval     time.Duration
+	checkDataInterval  time.Duration
 	plugins            map[string]*LogstreamInput
 	stopLogstreamChans []chan chan bool
 	stopChan           chan bool
@@ -77,11 +81,12 @@ func (li *LogstreamerInput) SetPipelineConfig(pConfig *p.PipelineConfig) {
 func (li *LogstreamerInput) ConfigStruct() interface{} {
 	baseDir := li.pConfig.Globals.BaseDir
 	return &LogstreamerInputConfig{
-		RescanInterval:   "1m",
-		OldestDuration:   "720h",
-		LogDirectory:     "/var/log",
-		JournalDirectory: filepath.Join(baseDir, "logstreamer"),
-		Splitter:         "TokenSplitter",
+		RescanInterval:    "1m",
+		CheckDataInterval: "250ms",
+		OldestDuration:    "720h",
+		LogDirectory:      "/var/log",
+		JournalDirectory:  filepath.Join(baseDir, "logstreamer"),
+		Splitter:          "TokenSplitter",
 	}
 }
 
@@ -113,6 +118,10 @@ func (li *LogstreamerInput) Init(config interface{}) (err error) {
 
 	// Setup the rescan interval.
 	if li.rescanInterval, err = time.ParseDuration(conf.RescanInterval); err != nil {
+		return
+	}
+	// Setup the check data interval.
+	if li.checkDataInterval, err = time.ParseDuration(conf.CheckDataInterval); err != nil {
 		return
 	}
 	// Parse the oldest duration.
@@ -168,7 +177,7 @@ func (li *LogstreamerInput) Init(config interface{}) (err error) {
 		if !ok {
 			continue
 		}
-		li.plugins[name] = NewLogstreamInput(stream, name, li.hostName)
+		li.plugins[name] = NewLogstreamInput(stream, name, li.hostName, li.checkDataInterval)
 	}
 	li.stopLogstreamChans = make([]chan chan bool, 0, len(plugins))
 	li.stopChan = make(chan bool)
@@ -240,7 +249,7 @@ func (li *LogstreamerInput) Run(ir p.InputRunner, h p.PluginHelper) (err error) 
 					continue
 				}
 
-				lsi := NewLogstreamInput(stream, name, li.hostName)
+				lsi := NewLogstreamInput(stream, name, li.hostName, li.checkDataInterval)
 				li.plugins[name] = lsi
 				i++
 				li.startLogstreamInput(lsi, i, ir, h)
@@ -260,6 +269,7 @@ type LogstreamInput struct {
 	stream              *ls.Logstream
 	loggerIdent         string
 	hostName            string
+	checkDataInterval   time.Duration
 	recordCount         int
 	stopped             chan bool
 	prevMsgWasTruncated bool
@@ -270,12 +280,13 @@ type LogstreamInput struct {
 }
 
 func NewLogstreamInput(stream *ls.Logstream, loggerIdent,
-	hostName string) *LogstreamInput {
+	hostName string, checkDataInterval time.Duration) *LogstreamInput {
 
 	return &LogstreamInput{
 		stream:              stream,
 		loggerIdent:         loggerIdent,
 		hostName:            hostName,
+		checkDataInterval:   checkDataInterval,
 		prevMsgWasTruncated: false,
 	}
 }
@@ -294,8 +305,7 @@ func (lsi *LogstreamInput) Run(ir p.InputRunner, h p.PluginHelper, stopChan chan
 	var err error
 
 	// Check for more data interval
-	interval, _ := time.ParseDuration("250ms")
-	tick := time.Tick(interval)
+	tick := time.Tick(lsi.checkDataInterval)
 
 	ok := true
 	for ok {


### PR DESCRIPTION
This change addresses the issue #1841. To avoid excessive CPU usage,
users can set a value higher than the default 250ms when they know that
a single logstreamer input may process many log files.
