### PR TITLE
sandbox_filter: allow user to override Hostname

### DIFF
--- a/sandbox/plugins/sandbox_filter.go
+++ b/sandbox/plugins/sandbox_filter.go
@@ -196,7 +196,10 @@ func (this *SandboxFilter) Run(fr pipeline.FilterRunner, h pipeline.PluginHelper
 				// do not allow filters to override the following
 				pack.Message.SetType("heka.sandbox." + pack.Message.GetType())
 				pack.Message.SetLogger(fr.Name())
-				pack.Message.SetHostname(hostname)
+				// allow the user to overwrite Hostname, else use current Hostname
+				if pack.Message.GetHostname() == "" {
+					pack.Message.SetHostname(hostname)
+				}
 			} else {
 				return 1
 			}


### PR DESCRIPTION
This change allows the user to set a message's Hostname in a Lua sandbox filter. It maintains the existing behavior, unless the Hostname is explicitly overridden.

The behavior we'd like is to be able to filter messages (sometimes: enriching/modifying fields) and the re-inject nearly the same message after passing through the filter. We need to preserve the Hostname since its value is used directly in downstream Outputs. Ultimately, we need the hostname of the original log in order to properly do metrics/alerts/search/etc. 

We're running Heka in a container and if you `inject_payload` to create a new message, you can't keep the original message's Hostname. Instead, the new message's hostname is Heka's container ID.
## 

In our pipeline, we use Hostname to mean "the host the log originated from".

It looks like the expected usage is ["Hostname that generated the message"](http://hekad.readthedocs.org/en/latest/message/#message-variables) -- perhaps you can illuminate if we are using it improperly. It seems like e.g. with an [RsyslogDecoder](http://hekad.readthedocs.org/en/latest/config/decoders/rsyslog.html#rsyslog-decoder), the `preserve_hostname` option means that Hostname should align with the host that created the log... that's exactly how we're using it.

Some core plugins rely on the Hostname of the Heka message, for example the [ElasticSearch plugin pulls directly from this field](https://github.com/mozilla-services/heka/blob/149c483a52f0f4c9ea50b73805feebed1b7c45c3/plugins/elasticsearch/encoders.go#L369-L370).

We also use it in many of our custom plugins. ([Example](https://github.com/Clever/heka-clever-plugins/blob/master/lua/filters/signalfxbatch.lua#L40-L50))
