### PR TITLE
Make the sending of ES coordinates optional, on by default.

### DIFF
--- a/plugins/elasticsearch/encoders_test.go
+++ b/plugins/elasticsearch/encoders_test.go
@@ -516,5 +516,33 @@ func ESEncodersSpec(c gs.Context) {
 				c.Expect(len(decoded), gs.Equals, 11) // 9 base fields and 2 dynamic fields.
 			})
 		})
+
+		c.Specify("handling ElasticSearch bulk coordinates", func() {
+			c.Specify("enables sending coordinates by default", func() {
+				c.Expect(config.SendCoords, gs.IsTrue)
+			})
+
+			c.Specify("doesn't send them when SendCoords is false", func() {
+				config.SendCoords = false
+				err := encoder.Init(config)
+				c.Assume(err, gs.IsNil)
+				b, err := encoder.Encode(pack)
+				c.Expect(err, gs.IsNil)
+
+				output := string(b)
+				c.Expect(strings.Contains(output, "index\":{\"_index"), gs.IsFalse)
+			})
+
+			c.Specify("sends them when SendCoords is true", func() {
+				config.SendCoords = true
+				err := encoder.Init(config)
+				c.Assume(err, gs.IsNil)
+				b, err := encoder.Encode(pack)
+				c.Expect(err, gs.IsNil)
+
+				output := string(b)
+				c.Expect(strings.Contains(output, "index\":{\"_index"), gs.IsTrue)
+			})
+		})
 	})
 }


### PR DESCRIPTION
The hand-constructed JSON encoding used for the `ESJsonEncoder` is very useful for other situations that aren't just sending the data to an ElasticSearch bulk API endpoint. Unfortunately because of the presence of the ES index coordinate records, it means that in those cases there are a lot of records present in the stream that aren't useful. We, for example, use this encoding to send data to a few different logging outputs where we want the message JSON in this format, but don't want to have to throw out all the index coordinates. This PR introduces a configuration option to make sending the coordinates optional, but preserving the default behavior.

It should have no effect at all on the normal use case, but allows it to be more flexible for outputs to non-ES backends.
