### PR TITLE
Add a remap_original_input_fields configuration option for JSON decoder.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -38,6 +38,8 @@ Features
 
 * Added `fields_from_labels` config option to DockerLogInput (#1843).
 
+* Added `remap_original_input_fields` config option to JSON decoder (#1867).
+
 0.10.1 (2016-??-??)
 ===================
 


### PR DESCRIPTION
This allows fields from the original message to be renamed and attached to the decoded messages. This is useful to capture fields set in input plugin pack decorators, e.g, capturing `RemoteAddr` from the HttpListenInput or capturing `Offset` from the KafkaInput.

The syntax is a little funky (space-delimited list of `newField=newField`). I didn't see an easy way to pass a map/table configuration value from the configuration `.toml` down into a `SandboxPlugin`. Is this a reasonable way to do this?
