### PR TITLE
Fix DockerEvents input

### DIFF
--- a/plugins/docker/docker_event.go
+++ b/plugins/docker/docker_event.go
@@ -31,7 +31,7 @@ func (dei *DockerEventInput) ConfigStruct() interface{} {
 
 func (dei *DockerEventInput) Init(config interface{}) error {
 	dei.conf = config.(*DockerEventInputConfig)
-	c, err := newDockerClient(dei.conf.Endpoint, dei.conf.CertPath)
+	c, err := newDockerClient(dei.conf.CertPath, dei.conf.Endpoint)
 	if err != nil {
 		return fmt.Errorf("DockerEventInput: failed to attach to docker event API: %s", err.Error())
 	}


### PR DESCRIPTION
Fixes argument ordering of call to newDockerClient

@relistan FYI: Seems your update changed the order of the args in `newDockerClient` from `(Endpoint, CertPath)` to `(CertPath, Endpoint)`
