### PR TITLE
Switch to docker's `logs` API endpoint, from `attach`, so we can

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,15 @@
 Backwards Incompatibilities
 ---------------------------
 
-* StatAccumInput Input: percent_threshold param type convert to slice
-* HttpInput Input: user param changed to username to match other Http plugins
+* StatAccumInput `percent_threshold` param type convert to slice.
+
+* HttpInput `user` param changed to `username` to match other HTTP plugins.
+
+* DockerLogInput changed to use `logs` API endpoint instead of `attach`. This
+  helps prevent data loss by allowing use of the `since` parameter to fetch
+  records that were generated while Heka was down, but it means this input will
+  now only work with containers using the `json-file` or `journald` logging
+  drivers.
 
 Bug Handling
 ------------
@@ -16,7 +23,7 @@ Bug Handling
 * Fixed ESJsonEncoder generating invalid JSON when `DynamicFields` is first of
   multiple specified fields but the message contains no dynamic fields.
 
-* Fixed bug where DockerLogInput would not reconnect when a Docker daemon 
+* Fixed bug where DockerLogInput would not reconnect when a Docker daemon
   was down for some time (#1843).
 
 * More verbose logging from the DockerLogInput plugin (#1843).

--- a/docs/source/config/inputs/docker_log.rst
+++ b/docs/source/config/inputs/docker_log.rst
@@ -52,6 +52,24 @@ Config:
 - fields_from_env (array[string], optional):
     A list of environment variables to extract from the container and add as fields.
 
+.. versionadded:: 0.11
+
+- since_path (string, optional):
+    Path to file where input will write a record of the "since" time for each
+    container to be able to not miss log records while Heka is down (see
+    Dockers `Get container logs
+    <https://docs.docker.com/engine/reference/api/docker_remote_api_v1.20/#get-container-logs>`_
+    API). Relative paths will be relative to Heka's configured
+    ``base_dir``. Defaults to `${BASE_DIR}/docker/logs_since.txt`
+- since_interval (string, optional):
+    Time interval (as supported by Go's `time.ParseDuration API
+    <https://golang.org/pkg/time/#ParseDuration>`_) that specifies how often
+    the DockerLogInput will write out the "since" file containing the most
+    recently retrieved log times for each container. Defaults to "5s". If set
+    to zero (e.g. "0s") then the file will only be written out when Heka
+    cleanly shuts down, meaning that if Heka crashes all container logs written
+    since Heka has started will be re-fetched.
+
 Example:
 
 .. code-block:: ini

--- a/plugins/docker/client.go
+++ b/plugins/docker/client.go
@@ -27,6 +27,11 @@ type DockerClient interface {
 	// See http://goo.gl/RRAhws for more details.
 	AttachToContainer(opts docker.AttachToContainerOptions) error
 
+	// Logs gets stdout and stderr log from the specified container.
+	//
+	// See http://goo.gl/yl8PGm for more details.
+	Logs(opts docker.LogsOptions) error
+
 	// Ping pings the docker server
 	//
 	// See https://goo.gl/kQCfJj for more details.

--- a/plugins/docker/docker_log_input.go
+++ b/plugins/docker/docker_log_input.go
@@ -17,7 +17,11 @@
 package docker
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"time"
 
 	"github.com/mozilla-services/heka/pipeline"
 )
@@ -26,36 +30,83 @@ type DockerLogInputConfig struct {
 	// A Docker endpoint.
 	Endpoint         string   `toml:"endpoint"`
 	CertPath         string   `toml:"cert_path"`
+	SincePath        string   `toml:"since_path"`
+	SinceInterval    string   `toml:"since_interval"`
 	NameFromEnv      string   `toml:"name_from_env_var"`
 	FieldsFromEnv    []string `toml:"fields_from_env"`
 	FieldsFromLabels []string `toml:"fields_from_labels"`
 }
 
 type DockerLogInput struct {
-	conf      *DockerLogInputConfig
 	stopChan  chan error
 	closer    chan struct{}
 	attachMgr *AttachManager
+	pConfig   *pipeline.PipelineConfig
+}
+
+func (di *DockerLogInput) SetPipelineConfig(pConfig *pipeline.PipelineConfig) {
+	di.pConfig = pConfig
 }
 
 func (di *DockerLogInput) ConfigStruct() interface{} {
 	return &DockerLogInputConfig{
-		Endpoint: "unix:///var/run/docker.sock",
-		CertPath: "",
+		Endpoint:      "unix:///var/run/docker.sock",
+		CertPath:      "",
+		SincePath:     filepath.Join("docker", "logs_since.txt"),
+		SinceInterval: "5s",
 	}
 }
 
 func (di *DockerLogInput) Init(config interface{}) error {
-	di.conf = config.(*DockerLogInputConfig)
+	conf := config.(*DockerLogInputConfig)
+	globals := di.pConfig.Globals
+
+	// Make sure since interval is valid.
+	sinceInterval, err := time.ParseDuration(conf.SinceInterval)
+	if err != nil {
+		return fmt.Errorf("Can't parse since_interval value '%s': %s", conf.SinceInterval,
+			err.Error())
+	}
+
+	// Make sure the since file exists.
+	sincePath := globals.PrependBaseDir(conf.SincePath)
+	_, err = os.Stat(sincePath)
+	if os.IsNotExist(err) {
+		sinceDir := filepath.Dir(sincePath)
+		if err = os.MkdirAll(sinceDir, 0700); err != nil {
+			return fmt.Errorf("Can't create storage directory '%s': %s", sinceDir,
+				err.Error())
+		}
+
+		sinceFile, err := os.Create(sincePath)
+		if err != nil {
+			return fmt.Errorf("Can't create \"since\" file '%s': %s", sincePath,
+				err.Error())
+		}
+		jsonEncoder := json.NewEncoder(sinceFile)
+		if err = jsonEncoder.Encode(&sinces{Containers: make(map[string]int64)}); err != nil {
+			return fmt.Errorf("Can't write to \"since\" file '%s': %s", sincePath,
+				err.Error())
+		}
+		if err = sinceFile.Close(); err != nil {
+			return fmt.Errorf("Can't close \"since\" file '%s': %s", sincePath,
+				err.Error())
+		}
+	} else if err != nil {
+		return fmt.Errorf("Can't open \"since\" file '%s': %s", sincePath, err.Error())
+	}
+
 	di.stopChan = make(chan error)
 	di.closer = make(chan struct{})
 
 	m, err := NewAttachManager(
-		di.conf.Endpoint,
-		di.conf.CertPath,
-		di.conf.NameFromEnv,
-		di.conf.FieldsFromEnv,
-		di.conf.FieldsFromLabels,
+		conf.Endpoint,
+		conf.CertPath,
+		conf.NameFromEnv,
+		conf.FieldsFromEnv,
+		conf.FieldsFromLabels,
+		sincePath,
+		sinceInterval,
 	)
 	if err != nil {
 		return fmt.Errorf("DockerLogInput: failed to attach: %s", err.Error())


### PR DESCRIPTION
not lose log messages when Heka is down.
