### PR TITLE
Unique items lua filter to support configurable time periods

### DIFF
--- a/sandbox/lua/filters/unique_items.lua
+++ b/sandbox/lua/filters/unique_items.lua
@@ -3,7 +3,7 @@
 -- file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 --[[
-Counts the number of unique items per day e.g. active daily users by uid.
+Counts the number of unique items per configurable time period e.g. active daily users by uid.
 
 Config:
 
@@ -17,6 +17,12 @@ Config:
     Specifies whether or not this plugin should generate cbuf deltas. Deltas
     should be enabled when sharding is used;
     see: :ref:`config_circular_buffer_delta_agg_filter`.
+
+- rows (uint, optional, default 365)
+    The numbers of rows or time periods to keep in history.
+
+- seconds_per_row (uint, optional, default 86400)
+    The number of seconds per row or time period, before switching to the next row.
 
 - preservation_version (uint, optional, default 0)
     If `preserve_data = true` is set in the SandboxFilter configuration, then
@@ -37,7 +43,21 @@ Config:
 
         [FxaActiveDailyUsers.config]
         message_variable = "Fields[uid]"
-        title = "Estimated Active Daily Users"
+        title = "Estimated Active Users Per Day"
+        preservation_version = 0
+
+    [FxaActiveHourlyUsers]
+    type = "SandboxFilter"
+    filename = "lua_filters/unique_items.lua"
+    ticker_interval = 60
+    rows = 24
+    seconds_per_row = 3600
+    preserve_data = true
+    message_matcher = "Logger == 'FxaAuth' && Type == 'request.summary' && Fields[path] == '/v1/certificate/sign' && Fields[errno] == 0"
+
+        [FxaActiveHourlyUsers.config]
+        message_variable = "Fields[uid]"
+        title = "Estimated Active Users Per Hour"
         preservation_version = 0
 --]]
 _PRESERVATION_VERSION = read_config("preservation_version") or 0
@@ -50,21 +70,23 @@ require "string"
 local message_variable  = read_config("message_variable") or error("message_variable configuration must be specified")
 local title             = read_config("title") or "Estimated Unique Daily " .. message_variable
 local enable_delta      = read_config("enable_delta") or false
+local rows              = read_config("rows") or 365
+local seconds_per_row   = read_config("seconds_per_row") or 60 * 60 * 24
 
-active_day  = 0
+active_period  = 0
 hll         = hyperloglog.new()
-active      = circular_buffer.new(365, 1, 60 * 60 * 24, enable_delta)
+active      = circular_buffer.new(rows, 1, seconds_per_row, enable_delta)
 local USERS = active:set_header(1, message_variable:match("^Fields%[([^%]]+)%]") or message_variable)
 local floor = math.floor
 
 function process_message ()
     local ts = read_message("Timestamp")
 
-    local day = floor(ts / (60 * 60 * 24 * 1e9))
-    if day < active_day  then
+    local period = floor(ts / (seconds_per_row * 1e9))
+    if period < active_period  then
         return 0 -- too old
-    elseif day > active_day then
-        active_day = day
+    elseif period > active_period then
+        active_period = period
         hll:clear()
     end
 


### PR DESCRIPTION
Currently the filter uses fixed buckets to track unique items
per day (seconds_per_row), keeping 365 days (rows). This change
modifies that behaviour to be configurable, as well as relevant
documentation updates and renaming variables to reflect they
track a time period and not a day.
