### PR TITLE
Update installing.rst: replaced 'source' with '.'

### DIFF
--- a/docs/source/installing.rst
+++ b/docs/source/installing.rst
@@ -70,7 +70,7 @@ Build Instructions
     .. code-block:: bash
 
         cd heka
-        . build.sh # Unix (or `. build.sh`; must be sourced to properly setup the environment)
+        . build.sh # Unix
         build.bat  # Windows
 
 You will now have a ``hekad`` binary in the ``build/heka/bin`` directory.

--- a/docs/source/installing.rst
+++ b/docs/source/installing.rst
@@ -70,7 +70,7 @@ Build Instructions
     .. code-block:: bash
 
         cd heka
-        source build.sh # Unix (or `. build.sh`; must be sourced to properly setup the environment)
+        . build.sh # Unix (or `. build.sh`; must be sourced to properly setup the environment)
         build.bat  # Windows
 
 You will now have a ``hekad`` binary in the ``build/heka/bin`` directory.


### PR DESCRIPTION
`source` is synonymous for `.` in bash and zsh only.
Some lighter shells don't have `source` command.
Moreover, only `.` is specified by POSIX.
So ksh, dash, ash, etc. may not have `source`.
