### PR TITLE
Support sending multiple fields per line to InfluxDB

### DIFF
--- a/sandbox/lua/encoders/schema_influx_line.lua
+++ b/sandbox/lua/encoders/schema_influx_line.lua
@@ -55,6 +55,17 @@ Config:
     from being mapped to the event altogether (useful if you don't want to
     use tags and embed them in the name_prefix instead).
 
+- multi_fields (boolean, optional, default false)
+    Instead of submitting all fields to InfluxDB as separate series, they can be
+    sent in only one serie instead of one for each field. If this is
+    enabled, the `name_prefix` option should be set or no measurement name
+    will be present when trying to send to InfluxDB. When this option is present,
+    only one line will be sent to InfluxDB for each message processed:
+
+    .. code-block:: none
+
+        cpu,Hostname=myhost,Environment=dev 5MinAvg=0.110000,1MinAvg=0.110000,15MinAvg=0.170000 1434932024
+
 - source_value_field (string, optional, default nil)
     If the desired behavior of this encoder is to extract one field from the
     Heka message and feed it as a single line to InfluxDB, then use this option
@@ -149,6 +160,7 @@ local decoder_config = {
     source_value_field = read_config("source_value_field") or nil,
     tag_fields_str = read_config("tag_fields") or "**all_base**",
     timestamp_precision = read_config("timestamp_precision") or "ms",
+    multi_fields = read_config("multi_fields") or false,
     value_field_key = read_config("value_field_key") or "value"
 }
 

--- a/sandbox/lua/filters/influx_batch.lua
+++ b/sandbox/lua/filters/influx_batch.lua
@@ -154,6 +154,7 @@ local filter_config = {
     source_value_field = read_config("source_value_field") or nil,
     tag_fields_str = read_config("tag_fields") or "**all_base**",
     timestamp_precision = read_config("timestamp_precision") or "ms",
+    multi_fields = read_config("multi_fields") or false,
     value_field_key = read_config("value_field_key") or "value"
 }
 

--- a/sandbox/lua/filters/influx_batch.lua
+++ b/sandbox/lua/filters/influx_batch.lua
@@ -56,6 +56,17 @@ Config:
     from being mapped to the event altogether (useful if you don't want to
     use tags and embed them in the name_prefix instead).
 
+- multi_fields (boolean, optional, default false)
+    Instead of submitting all fields to InfluxDB as separate series, they can be
+    sent in only one serie instead of one for each field. If this is
+    enabled, the `name_prefix` option should be set or no measurement name
+    will be present when trying to send to InfluxDB. When this option is present,
+    only one line will be sent to InfluxDB for each message processed:
+
+    .. code-block:: none
+
+        cpu,Hostname=myhost,Environment=dev 5MinAvg=0.110000,1MinAvg=0.110000,15MinAvg=0.170000 1434932024
+
 - source_value_field (string, optional, default nil)
     If the desired behavior of this encoder is to extract one field from the
     Heka message and feed it as a single line to InfluxDB, then use this option

--- a/sandbox/plugins/sandbox_encoders_test.go
+++ b/sandbox/plugins/sandbox_encoders_test.go
@@ -345,7 +345,7 @@ byteField,Logger=Logger,Hostname=hostname,strField=0_first,strField_vidx_1=0_sec
 			c.Assume(err, gs.IsNil)
 			result, err := encoder.Encode(pack)
 			c.Expect(err, gs.IsNil)
-			expected := `multiple_fields,Logger=Logger,Type=my_type,Severity=4,Hostname=hostname byteField_vidx_1="second",intField_vidx_1=456.000000,byteField="first",strField_fidx_1_vidx_1="1_second",strField_vidx_1="0_second",intField=123.000000,strField_fidx_1="1_first",strField="0_first" 54321000
+			expected := `multiple_fields,Logger=Logger,Type=my_type,Severity=4,Hostname=hostname byteField="first",byteField_vidx_1="second",strField_fidx_1="1_first",strField_fidx_1_vidx_1="1_second",strField="0_first",strField_vidx_1="0_second",intField=123.000000,intField_vidx_1=456.000000 54321000
 `
 			c.Expect(string(result), gs.Equals, expected)
 		})

--- a/sandbox/plugins/sandbox_encoders_test.go
+++ b/sandbox/plugins/sandbox_encoders_test.go
@@ -324,7 +324,6 @@ byteField,Logger=Logger,Type=my_type,Severity=4,Hostname=hostname value="first" 
 		})
 
 		c.Specify("honors tag_fields", func() {
-			conf.Config["multi_fields"] = true
 			conf.Config["tag_fields"] = "Hostname Logger strField"
 			conf.Config["skip_fields"] = "strField"
 			err = encoder.Init(conf)
@@ -335,6 +334,18 @@ byteField,Logger=Logger,Type=my_type,Severity=4,Hostname=hostname value="first" 
 byteField_vidx_1,Logger=Logger,Hostname=hostname,strField=0_first,strField_vidx_1=0_second,strField_fidx_1=1_first,strField_fidx_1_vidx_1=1_second value="second" 54321000
 intField,Logger=Logger,Hostname=hostname,strField=0_first,strField_vidx_1=0_second,strField_fidx_1=1_first,strField_fidx_1_vidx_1=1_second value=123.000000 54321000
 byteField,Logger=Logger,Hostname=hostname,strField=0_first,strField_vidx_1=0_second,strField_fidx_1=1_first,strField_fidx_1_vidx_1=1_second value="first" 54321000
+`
+			c.Expect(string(result), gs.Equals, expected)
+		})
+
+		c.Specify("encodes a message with multiple fields in one line", func() {
+			conf.Config["multi_fields"] = true
+			conf.Config["name_prefix"] = "multiple_fields"
+			err = encoder.Init(conf)
+			c.Assume(err, gs.IsNil)
+			result, err := encoder.Encode(pack)
+			c.Expect(err, gs.IsNil)
+			expected := `multiple_fields,Logger=Logger,Type=my_type,Severity=4,Hostname=hostname byteField_vidx_1="second",intField_vidx_1=456.000000,byteField="first",strField_fidx_1_vidx_1="1_second",strField_vidx_1="0_second",intField=123.000000,strField_fidx_1="1_first",strField="0_first" 54321000
 `
 			c.Expect(string(result), gs.Equals, expected)
 		})

--- a/sandbox/plugins/sandbox_filters_test.go
+++ b/sandbox/plugins/sandbox_filters_test.go
@@ -770,7 +770,7 @@ intField_vidx_1,Logger=Logger,Type=my_type,Severity=4,Hostname=hostname value=45
 			// timer <- time.Now()
 			m := <-retMsgChan
 
-                        msgStr := `multiple_fields,Logger=Logger,Type=my_type,Severity=4,Hostname=hostname byteField_vidx_1="second",intField_vidx_1=456.000000,byteField="first",strField_fidx_1_vidx_1="1_second",strField_vidx_1="0_second",intField=%d.000000,strField_fidx_1="1_first",strField="0_first" 54321000
+			msgStr := `multiple_fields,Logger=Logger,Type=my_type,Severity=4,Hostname=hostname byteField="first",byteField_vidx_1="second",strField_fidx_1="1_first",strField_fidx_1_vidx_1="1_second",strField="0_first",strField_vidx_1="0_second",intField=%d.000000,intField_vidx_1=456.000000 54321000
 `
 			pl := ""
 			for i := 0; i < 6; i++ {


### PR DESCRIPTION
As described in [InfluxDB docs](https://docs.influxdata.com/influxdb/v0.12/write_protocols/line/), the line protocol supports sending multiple fields in one line. When you have multiple values sharing the same measurement, tags and timestamp, sending them all at once ca speed up things.

This PR adds a config option to the Schema InfluxDB Line Encoder and the InfluxDB Batch Filter. If `multi_fields` is `false`, the behavior is the same as before. But if it's set to `true`, all fields that are not skipped will be used as fields with their corresponding values in the line sent to InfluxDB. `multi_fields` defaults to `false`.

If, for example, we want to send the fields `free` and `used` for a measurement `memory`, with `multi_fields` set to `false`, the lines sent would look like:

```
free value=858993459 1434932024
used value=3435973836 1434932024
```

But with `multi_fields` set to `true`, there would be only one line:

```
memory free=858993459,used=3435973836 1434932024
```

`memory` would need to be set as the `name_prefix`.
