### PR TITLE
Add ability to deflate gzip'd payloads in HttpListenInput

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -51,6 +51,8 @@ Features
 
 * Added iowait percentage output field in filter procstat (#1888).
 
+* Added ability to deflate gzip'd payloads in HttpListenInput.
+
 0.10.1 (2016-??-??)
 ===================
 

--- a/docs/source/config/inputs/httplisten.rst
+++ b/docs/source/config/inputs/httplisten.rst
@@ -72,6 +72,12 @@ Config:
     encryption. This will only have any impact if `use_tls` is set to true.
     See :ref:`tls`.
 
+.. versionadded:: 0.11
+
+- deflate (bool):
+    If true and a request has the "Content-Encoding" header set to "gzip", attempt
+    to deflate the body.
+
 Example:
 
 .. code-block:: ini


### PR DESCRIPTION
Useful for uncompressing data from something like http://bosun.org/scollector/ or other gzip'd payloads that need splitting before decoding?
