### PR TITLE
Graylog native go plugin

### DIFF
--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -208,3 +208,5 @@ if (PLUGIN_LOADER)
     set(_PLUGIN_LOADER_OUTPUT "${_PLUGIN_LOADER_OUTPUT}\n)\n")
     file(WRITE "${CMAKE_BINARY_DIR}/plugin_loader.go" ${_PLUGIN_LOADER_OUTPUT})
 endif()
+
+git_clone(https://github.com/Graylog2/go-gelf 76d60fc890684cff2fb65c631ed711d4af080592)

--- a/cmd/hekad/main.go
+++ b/cmd/hekad/main.go
@@ -41,6 +41,7 @@ import (
 	_ "github.com/mozilla-services/heka/plugins/elasticsearch"
 	_ "github.com/mozilla-services/heka/plugins/file"
 	_ "github.com/mozilla-services/heka/plugins/graphite"
+	_ "github.com/mozilla-services/heka/plugins/graylog"
 	_ "github.com/mozilla-services/heka/plugins/http"
 	_ "github.com/mozilla-services/heka/plugins/irc"
 	_ "github.com/mozilla-services/heka/plugins/kafka"

--- a/plugins/graylog/graylog_input.go
+++ b/plugins/graylog/graylog_input.go
@@ -9,7 +9,6 @@ import (
 
 type GraylogInputConfig struct{
 	Address string `toml:"address"`
-	Type string `toml:"type"`
 }
 
 type GraylogInput struct {
@@ -58,9 +57,9 @@ func (g *GraylogInput) Run(ir pipeline.InputRunner, h pipeline.PluginHelper) (er
 					break
 				}
 			}
-
-			close(g.ctrlMsgs)
 		}
+		close(g.ctrlMsgs)
+
 	}()
 
 	for ctrlMsg := range g.ctrlMsgs {
@@ -80,8 +79,9 @@ func (g *GraylogInput) Run(ir pipeline.InputRunner, h pipeline.PluginHelper) (er
 		}
 
 		pack.Message.SetUuid(uuid.NewRandom())
-		pack.Message.SetTimestamp(int64(msg.TimeUnix) * 1000000)
-		pack.Message.SetType(g.config.Type)
+		pack.Message.SetTimestamp(int64(msg.TimeUnix) * 1000000000)
+		pack.Message.SetType("heka.graylog")
+		pack.Message.SetHostname(msg.Host)
 		pack.Message.SetSeverity(msg.Level)
 		pack.Message.SetLogger(g.config.Address)
 		ir.Deliver(pack)

--- a/plugins/graylog/graylog_input.go
+++ b/plugins/graylog/graylog_input.go
@@ -1,0 +1,101 @@
+package graylog
+
+import (
+	"github.com/pborman/uuid"
+
+	"github.com/mozilla-services/heka/pipeline"
+	"github.com/Graylog2/go-gelf/gelf"
+)
+
+type GraylogInputConfig struct{
+	Address string `toml:"address"`
+	Type string `toml:"type"`
+}
+
+type GraylogInput struct {
+	config *GraylogInputConfig
+	reader *gelf.Reader
+
+	ctrlMsgs chan gelfCtrl
+	stopChan chan bool
+}
+
+func (g *GraylogInput) ConfigStruct() interface{} {
+	return &GraylogInputConfig{
+	}
+}
+
+func (g *GraylogInput) Init(config interface{}) (err error) {
+	g.config = config.(*GraylogInputConfig)	
+	g.ctrlMsgs = make(chan gelfCtrl)
+	g.stopChan = make(chan bool)
+	g.reader,err = gelf.NewReader(g.config.Address)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+type gelfCtrl struct {
+	err error
+	message *gelf.Message
+}
+
+func (g *GraylogInput) Run(ir pipeline.InputRunner, h pipeline.PluginHelper) (err error) {
+	go func() {
+		for {
+			select {
+			case <-g.stopChan:
+				break
+			default:
+				message,err := g.reader.ReadMessage()
+				g.ctrlMsgs <- gelfCtrl {
+					err: err,
+					message: message,
+				}
+				if err != nil {
+					break
+				}
+			}
+
+			close(g.ctrlMsgs)
+		}
+	}()
+
+	for ctrlMsg := range g.ctrlMsgs {
+		if ctrlMsg.err != nil {
+			ir.LogError(ctrlMsg.err)
+			err = ctrlMsg.err
+			break
+		}
+
+		msg := ctrlMsg.message
+
+		pack := <-ir.InChan()
+		if msg.Full != "" {
+			pack.Message.SetPayload(msg.Full)
+		} else {
+			pack.Message.SetPayload(msg.Short)
+		}
+
+		pack.Message.SetUuid(uuid.NewRandom())
+		pack.Message.SetTimestamp(int64(msg.TimeUnix) * 1000000)
+		pack.Message.SetType(g.config.Type)
+		pack.Message.SetSeverity(msg.Level)
+		pack.Message.SetLogger(g.config.Address)
+		ir.Deliver(pack)
+	}
+
+	return
+}
+
+func (g *GraylogInput) Stop() {
+	close(g.stopChan)
+}
+
+func init() {
+	pipeline.RegisterPlugin("GraylogInput", func() interface{} {
+		return new(GraylogInput)
+	})
+}


### PR DESCRIPTION
I needed to get logs out of the docker daemon and the most attractive option was graylog. Problem is that my version of docker (1.9) could not disable compression and the simple graylog decoder was not going to be sufficient. So I tackled the native plugin. This should be a useful addition for other heka/docker users.
