### PR TITLE
Beefed up .travis.yml so we can get automatic builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,16 @@ notifications:
     irc:
         channels:
             - "irc.mozilla.org#heka"
+services:
+    - docker
 addons:
     apt:
         packages:
         - protobuf-compiler
         - cmake
         - libgeoip-dev
+        - debhelper
 install:
     - . build.sh
 script:
-    - make test
+    - make test && make deb && ./../docker/release_travis.sh

--- a/docker/Dockerfile.travis
+++ b/docker/Dockerfile.travis
@@ -1,0 +1,5 @@
+FROM debian:jessie
+MAINTAINER Xavier Lange <xrlange@tureus.com> (@tureus)
+
+ADD heka.deb /tmp/heka.deb
+RUN apt-get update && apt-get install -y libgeoip1 && dpkg -i /tmp/heka.deb && rm /tmp/heka.deb

--- a/docker/TRAVIS_README.md
+++ b/docker/TRAVIS_README.md
@@ -1,0 +1,25 @@
+TRAVIS README
+====
+
+[Travis CI](https://travis-ci.org) is used to run the heka test suite on every push and pull request to github. Those travis runs end with a docker build and push to the semi-official docker repository.
+
+Travis Setup
+---
+
+The docker build relies on environmental variables being set for login. Here they are, in case you'd like to auto build heka for your fork. You'll need to install the travis command line tool and inject some docker variables:
+
+```
+gem install travis
+travis login --org
+travis env set DOCKER_EMAIL $YOUR_DOCKER_ACCT_EMAIL
+travis env set DOCKER_USERNAME $YOUR_DOCKER_ACCT_USERNAME
+travis env set DOCKER_PASSWORD $YOUR_DOCKER_ACCT_PASSWD
+travis env set --public DOCKER_REPO_SLUG xrlx/heka
+```
+
+These values are used by the `docker/release_travis.sh`. The unit tests must pass for the docker image to be built.
+
+Docker Images
+---
+
+The `$DOCKER_REPO_SLUG` is used to craft the `docker push $DOCKER_REPO_SLUG:$TAG`. The `$TAG` is determined using a git tag, if that's what kicked off travis, or more like the git branch which received a push. Pull requests will not generate image builds.

--- a/docker/release_travis.sh
+++ b/docker/release_travis.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -ex
+
+if [[ $DOCKER_REPO_SLUG == "" ]]; then
+  echo "must set DOCKER_REPO_SLUG ENV var"
+  exit 1
+fi
+
+if [[ $TRAVIS_TAG != "" ]]; then
+  DOCKER_TAG=$TRAVIS_TAG
+elif [[ $TRAVIS_BRANCH != "" ]]; then
+  DOCKER_TAG=$TRAVIS_BRANCH
+else
+  echo "Skipping docker build because this is a pull request (${TRAVIS_PULL_REQUEST})"
+  exit 0
+fi
+
+IMAGE="${DOCKER_REPO_SLUG}:${TRAVIS_BRANCH}"
+
+cd $TRAVIS_BUILD_DIR
+mkdir /tmp/heka
+find . -name "*.deb" -exec cp {} /tmp/heka/heka.deb \;
+cp docker/Dockerfile.travis /tmp/heka/Dockerfile
+
+docker build -t $IMAGE /tmp/heka
+docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+docker push $IMAGE


### PR DESCRIPTION
Generate docker images after successful build and push up to the central docker registry. We'll need the heka project to create an account on the registry and then inject credentials for this travis to work.

You'll need to install the travis command line tool and inject some docker variables:

```
gem install travis
travis login --org
travis env set DOCKER_EMAIL $YOUR_DOCKER_ACCT_EMAIL
travis env set DOCKER_USERNAME $YOUR_DOCKER_ACCT_USERNAME
travis env set DOCKER_PASSWORD $YOUR_DOCKER_ACCT_PASSWD
travis env set --public DOCKER_REPO_SLUG mozilla-services/heka
```

These values are used by the `docker/release_travis.sh`. By default `env set` creates private variables which don't show up in the build logs. The `DOCKER_REPO_SLUG` is made public so it can be clear where the image is going. The unit tests must pass for the docker image to be built.
