### PR TITLE
Fix operational issue when upgrading to newer DockerLogInput from old one

### DIFF
--- a/docs/source/config/inputs/docker_log.rst
+++ b/docs/source/config/inputs/docker_log.rst
@@ -54,6 +54,9 @@ Config:
 
 .. versionadded:: 0.11
 
+- fields_from_labels (array[string], optional):
+    A list of labels to pull is as fields. These are pulled in last and will
+	override any fields added from fields_from_env.
 - since_path (string, optional):
     Path to file where input will write a record of the "since" time for each
     container to be able to not miss log records while Heka is down (see
@@ -69,6 +72,18 @@ Config:
     to zero (e.g. "0s") then the file will only be written out when Heka
     cleanly shuts down, meaning that if Heka crashes all container logs written
     since Heka has started will be re-fetched.
+- container_expiry_days (int, optional):
+    The number of days after which to remove unseen containers from the sinces
+	file. Defaults to 30 days. This prevents containers from building up
+	in the file forever. It has the effect of replaying logs from any container
+	which was not seen for this interval but then re-appears. Containers are
+	tracked by container ID.
+- new_containers_replay_logs (bool, optional):
+    Will newly discovered containers replay all of the logs currently available
+	via the Docker logs endpoint? Defaults to true. If you are upgrading from
+	a previous version of heka, you may want to consider setting this to false
+	when first upgrading to prevent the massive replay of logs from all of
+	your existing containers.
 
 Example:
 

--- a/docs/source/config/inputs/docker_log.rst
+++ b/docs/source/config/inputs/docker_log.rst
@@ -56,7 +56,7 @@ Config:
 
 - fields_from_labels (array[string], optional):
     A list of labels to pull is as fields. These are pulled in last and will
-	override any fields added from fields_from_env.
+    override any fields added from fields_from_env.
 - since_path (string, optional):
     Path to file where input will write a record of the "since" time for each
     container to be able to not miss log records while Heka is down (see
@@ -74,16 +74,16 @@ Config:
     since Heka has started will be re-fetched.
 - container_expiry_days (int, optional):
     The number of days after which to remove unseen containers from the sinces
-	file. Defaults to 30 days. This prevents containers from building up
-	in the file forever. It has the effect of replaying logs from any container
-	which was not seen for this interval but then re-appears. Containers are
-	tracked by container ID.
+    file. Defaults to 30 days. This prevents containers from building up
+    in the file forever. It has the effect of replaying logs from any container
+    which was not seen for this interval but then re-appears. Containers are
+    tracked by container ID.
 - new_containers_replay_logs (bool, optional):
     Will newly discovered containers replay all of the logs currently available
-	via the Docker logs endpoint? Defaults to true. If you are upgrading from
-	a previous version of heka, you may want to consider setting this to false
-	when first upgrading to prevent the massive replay of logs from all of
-	your existing containers.
+    via the Docker logs endpoint? Defaults to true. If you are upgrading from
+    a previous version of heka, you may want to consider setting this to false
+    when first upgrading to prevent the massive replay of logs from all of
+    your existing containers.
 
 Example:
 

--- a/plugins/docker/attacher.go
+++ b/plugins/docker/attacher.go
@@ -172,6 +172,10 @@ func (m *AttachManager) writeSinceFile(t time.Time) {
 	// Eject since containers that are too old to keep so we don't build up
 	// a list forever.
 	for container, lastSeen := range m.sinces.Containers {
+		if lastSeen == 0 {
+			continue
+		}
+
 		if lastSeen < time.Now().Unix() - int64(m.containerExpiryDays) * 3600 * 24 {
 			delete(m.sinces.Containers, container)
 		}
@@ -293,7 +297,7 @@ func (m *AttachManager) attach(id string, client DockerClient) error {
 			// We haven't seen it, add it to our sinces.
 			m.sinces.Containers[id] = 0
 
-			// And set the since appropriately from our settings
+			// And set the since appropriately from our settings.
 			if !m.newContainersReplayLogs {
 				// Use the last global since time when we connect to it
 				since = m.sinces.Since

--- a/plugins/docker/since_tracker.go
+++ b/plugins/docker/since_tracker.go
@@ -1,0 +1,150 @@
+/***** BEGIN LICENSE BLOCK *****
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# The Initial Developer of the Original Code is the Mozilla Foundation.
+# Portions created by the Initial Developer are Copyright (C) 2014
+# the Initial Developer. All Rights Reserved.
+#
+# Contributor(s):
+#   Rob Miller (rmiller@mozilla.com)
+#   Karl Matthias (karl.matthias@gonitro.com)
+#
+# ***** END LICENSE BLOCK *****/
+
+package docker
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/mozilla-services/heka/pipeline"
+)
+
+// Tracks the timestamp of the last time we logged
+// data from a particular container.
+type SinceTracker struct {
+	sync.Mutex
+	Path       string        `json:"-"`
+	Interval   time.Duration `json:"-"`
+	ExpiryDays int           `json:"-"`
+	Since      int64
+	Containers map[string]int64
+	ir         pipeline.InputRunner
+}
+
+// Return a fully configured SinceTracker.
+func NewSinceTracker(expiryDays int, path string, interval time.Duration) (*SinceTracker, error) {
+	sinceTracker := &SinceTracker{
+		Path:       path,
+		Interval:   interval,
+		ExpiryDays: expiryDays,
+	}
+
+	if err := sinceTracker.Load(); err != nil {
+		return nil, err
+	}
+
+	return sinceTracker, nil
+}
+
+// Load state from the since file into the SinceTracker.
+func (s *SinceTracker) Load() error {
+	// Initialize the sinces from the JSON since file.
+	sinceFile, err := os.Open(s.Path)
+	if err != nil {
+		return fmt.Errorf("Can't open \"since\" file '%s': %s", s.Path, err.Error())
+	}
+
+	jsonDecoder := json.NewDecoder(sinceFile)
+
+	s.Lock()
+	err = jsonDecoder.Decode(s)
+	s.Unlock()
+
+	if err != nil {
+		return fmt.Errorf("Can't decode \"since\" file '%s': %s", s.Path, err.Error())
+	}
+
+	return nil
+}
+
+// Write out the current data in the SinceTracker to the sinces file.
+func (s *SinceTracker) Write(t time.Time) {
+	sinceFile, err := os.Create(s.Path)
+	if err != nil {
+		s.ir.LogError(fmt.Errorf("Can't create \"since\" file '%s': %s", s.Path,
+			err.Error()))
+		return
+	}
+	jsonEncoder := json.NewEncoder(sinceFile)
+	s.Lock()
+	s.Since = t.Unix()
+
+	// Eject since containers that are too old to keep so we don't build up
+	// a list forever.
+	for container, lastSeen := range s.Containers {
+		if lastSeen == 0 {
+			continue
+		}
+
+		if lastSeen < time.Now().Unix()-int64(s.ExpiryDays)*3600*24 {
+			delete(s.Containers, container)
+		}
+	}
+
+	// Whitelist the parts of the struct we save to disk
+	outStruct := struct {
+		Since      *int64
+		Containers *map[string]int64
+	}{&s.Since, &s.Containers}
+
+	if err = jsonEncoder.Encode(outStruct); err != nil {
+		s.ir.LogError(fmt.Errorf("Can't write to \"since\" file '%s': %s", s.Path,
+			err.Error()))
+	}
+
+	s.Unlock()
+	if err = sinceFile.Close(); err != nil {
+		s.ir.LogError(fmt.Errorf("Can't close \"since\" file '%s': %s", s.Path,
+			err.Error()))
+	}
+}
+
+// Make sure the file exists and is writable
+func EnsureSincesFile(conf *DockerLogInputConfig, sincePath string) error {
+	// Make sure the since file exists.
+	_, err := os.Stat(sincePath)
+	if os.IsNotExist(err) {
+		sinceDir := filepath.Dir(sincePath)
+		if err = os.MkdirAll(sinceDir, 0700); err != nil {
+			return fmt.Errorf("Can't create storage directory '%s': %s", sinceDir,
+				err.Error())
+		}
+
+		sinceFile, err := os.Create(sincePath)
+		if err != nil {
+			return fmt.Errorf("Can't create \"since\" file '%s': %s", sincePath,
+				err.Error())
+		}
+
+		jsonEncoder := json.NewEncoder(sinceFile)
+		if err = jsonEncoder.Encode(&SinceTracker{Containers: make(map[string]int64)}); err != nil {
+			return fmt.Errorf("Can't write to \"since\" file '%s': %s", sincePath,
+				err.Error())
+		}
+		if err = sinceFile.Close(); err != nil {
+			return fmt.Errorf("Can't close \"since\" file '%s': %s", sincePath,
+				err.Error())
+		}
+	} else if err != nil {
+		return fmt.Errorf("Can't open \"since\" file '%s': %s", sincePath, err.Error())
+	}
+
+	return nil
+}


### PR DESCRIPTION
We ran into some trouble when you upgrade from the existing `DockerLogInput` plugin to the current one on `dev`. That's because switching from using `attach` to `logs` on the Docker API means that we're going to pull in all the past logs for containers that in some cases have been up for quite some time. This leads to some pretty massive duplication of logs and a burying of the downstream logging system for awhile. Secondly, there is currently no way to expire entries from the sinces JSON file and so for systems with a lot of deployments, the list just grows and grows.

This PR fixes both of those issues by introducing some settings:
1. `new_containers_replay_logs` - Allows disabling of replay of logs for existing containers. This should be set to `true` when upgrading. It can later be switched back to help guarantee log delivery while Heka is not listening. Defaults to `true`
2. `container_expiry_days` - Represents the number of days to keep a container ID in the file after we last see it. Defaults to 30 days.

There is some additional refactoring of the code for encapsulation and readability. Finally it adds documentation for a missing setting introduced earlier, `fields_from_labels`.
