### PR TITLE
Catch when stats channel is closed

### DIFF
--- a/plugins/docker/stats_handling.go
+++ b/plugins/docker/stats_handling.go
@@ -184,7 +184,6 @@ func (m *StatsManager) statsAttach(id string, client DockerClient) error {
 		})
 
 		// Once it has exited, close our pipes
-		close(statsrd)
 		close(done)
 		if err != nil {
 			failure <- err
@@ -325,7 +324,10 @@ func NewStatsPump(statsChan chan *docker.Stats, name string, fields map[string]s
 	// from the channel
 	pump := func(sourceChan chan *docker.Stats, fields map[string]string) {
 		for {
-			source := <-sourceChan
+			source, ok := <-sourceChan
+			if !ok{
+				return
+			}
 			json_ver, _ := json.Marshal(source)
 			// Send a DockerStat struct out
 			obj.send(&DockerStat{


### PR DESCRIPTION
- Discovered during use that removal of a container the plugin has been attached to causes a panic due to attempting to close the statsrd channel when already closed by the go-dockerclient. This fix means it no longer attempts to do this and ensures it returns from the gofunc when it is closed.

I should have caught this sooner and only found it when using it in anger. Pretty sure this is the best way to solve the issue but any feedback is appreciated as usual.
