### PR TITLE
Memory map kafka checkpoint file

### DIFF
--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -161,6 +161,7 @@ git_clone(https://github.com/rafrombrc/gospec 2e46585948f47047b0c217d00fa24bbc4e
 git_clone(https://github.com/crankycoder/xmlpath 670b185b686fd11aa115291fb2f6dc3ed7ebb488)
 git_clone(https://github.com/thoj/go-ircevent 90dc7f966b95d133f1c65531c6959b52effd5e40)
 git_clone(https://github.com/cactus/gostrftime d329f83c5ce9c416f8983f0a0044734db54ee24d)
+git_clone(https://github.com/edsrzf/mmap-go 935e0e8a636ca4ba70b713f3e38a19e1b77739e8)
 
 git_clone(https://github.com/golang/snappy 723cc1e459b8eea2dea4583200fd60757d40097a)
 git_clone(https://github.com/eapache/go-resiliency v1.0.0)


### PR DESCRIPTION
# Problem

Heka's KafkaInput plugin writes the offset for every Kafka message. When it's a low volume topic, this doesn't cause any issues, but with high volume ones, disk IO becomes a limiting factor to how quickly Heka can process messages.
# Solution

Instead of writing the offset on every message to disk, this PR `mmap`s it. A quick benchmark shows the advantages of using this method:

```
BenchmarkFile-8                  10000         119687 ns/op
BenchmarkMmap-8             2000000000           0.64 ns/op
```

No new tests were written, and the ones that verify checkpoint correctness still pass.

r. @fbogsany @rafrombrc
