### PR TITLE
Remove unused import

### DIFF
--- a/plugins/udp/udp_input.go
+++ b/plugins/udp/udp_input.go
@@ -23,7 +23,6 @@ import (
 	"strconv"
 	"strings"
 
-	. "github.com/mozilla-services/heka/message"
 	. "github.com/mozilla-services/heka/pipeline"
 )
 


### PR DESCRIPTION
I get the following error when building heka. This pull request removes the unused import 

heka/plugins/udp/udp_input.go:26: imported and not used: "github.com/mozilla-services/heka/message"
make[2]: **\* [CMakeFiles/hekad] Error 2
make[1]: **\* [CMakeFiles/hekad.dir/all] Error 2
make: **\* [all] Error 2
