### PR TITLE
Update sarama to upstream 1.9. Also updates sarama dependencies.

### DIFF
--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -162,7 +162,7 @@ git_clone(https://github.com/crankycoder/xmlpath 670b185b686fd11aa115291fb2f6dc3
 git_clone(https://github.com/thoj/go-ircevent 90dc7f966b95d133f1c65531c6959b52effd5e40)
 git_clone(https://github.com/cactus/gostrftime d329f83c5ce9c416f8983f0a0044734db54ee24d)
 
-git_clone(github.com/eapache/go-xerial-snappy bb955e01b9346ac19dc29eb16586c90ded99a98c)
+git_clone(https://github.com/eapache/go-xerial-snappy bb955e01b9346ac19dc29eb16586c90ded99a98c)
 git_clone(https://github.com/eapache/go-resiliency b86b1ec0dd4209a588dc1285cdd471e73525c0b3)
 git_clone(https://github.com/eapache/queue v1.0.2)
 git_clone(https://github.com/Shopify/sarama e8020bffa1cae3ddf8068cb03416fc53d1627f3d)

--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -162,7 +162,7 @@ git_clone(https://github.com/crankycoder/xmlpath 670b185b686fd11aa115291fb2f6dc3
 git_clone(https://github.com/thoj/go-ircevent 90dc7f966b95d133f1c65531c6959b52effd5e40)
 git_clone(https://github.com/cactus/gostrftime d329f83c5ce9c416f8983f0a0044734db54ee24d)
 
-git_clone(https://github.com/golang/snappy d9eb7a3d35ec988b8585d4a0068e462c27d28380)
+git_clone(github.com/eapache/go-xerial-snappy bb955e01b9346ac19dc29eb16586c90ded99a98c)
 git_clone(https://github.com/eapache/go-resiliency b86b1ec0dd4209a588dc1285cdd471e73525c0b3)
 git_clone(https://github.com/eapache/queue v1.0.2)
 git_clone(https://github.com/Shopify/sarama e8020bffa1cae3ddf8068cb03416fc53d1627f3d)

--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -165,7 +165,7 @@ git_clone(https://github.com/cactus/gostrftime d329f83c5ce9c416f8983f0a0044734db
 git_clone(https://github.com/golang/snappy d9eb7a3d35ec988b8585d4a0068e462c27d28380)
 git_clone(https://github.com/eapache/go-resiliency b86b1ec0dd4209a588dc1285cdd471e73525c0b3)
 git_clone(https://github.com/eapache/queue v1.0.2)
-git_clone(https://github.com/Shopify/sarama 38d579a708d2f87dd4e35342241048e361d1e66a)
+git_clone(https://github.com/Shopify/sarama e8020bffa1cae3ddf8068cb03416fc53d1627f3d)
 git_clone(https://github.com/klauspost/crc32 19b0b332c9e4516a6370a0456e6182c3b5036720)
 git_clone(https://github.com/davecgh/go-spew 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d)
 

--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -162,6 +162,7 @@ git_clone(https://github.com/crankycoder/xmlpath 670b185b686fd11aa115291fb2f6dc3
 git_clone(https://github.com/thoj/go-ircevent 90dc7f966b95d133f1c65531c6959b52effd5e40)
 git_clone(https://github.com/cactus/gostrftime d329f83c5ce9c416f8983f0a0044734db54ee24d)
 
+git_clone(https://github.com/golang/snappy d9eb7a3d35ec988b8585d4a0068e462c27d28380)
 git_clone(https://github.com/eapache/go-xerial-snappy bb955e01b9346ac19dc29eb16586c90ded99a98c)
 git_clone(https://github.com/eapache/go-resiliency b86b1ec0dd4209a588dc1285cdd471e73525c0b3)
 git_clone(https://github.com/eapache/queue v1.0.2)

--- a/cmake/externals.cmake
+++ b/cmake/externals.cmake
@@ -162,11 +162,12 @@ git_clone(https://github.com/crankycoder/xmlpath 670b185b686fd11aa115291fb2f6dc3
 git_clone(https://github.com/thoj/go-ircevent 90dc7f966b95d133f1c65531c6959b52effd5e40)
 git_clone(https://github.com/cactus/gostrftime d329f83c5ce9c416f8983f0a0044734db54ee24d)
 
-git_clone(https://github.com/golang/snappy 723cc1e459b8eea2dea4583200fd60757d40097a)
-git_clone(https://github.com/eapache/go-resiliency v1.0.0)
+git_clone(https://github.com/golang/snappy d9eb7a3d35ec988b8585d4a0068e462c27d28380)
+git_clone(https://github.com/eapache/go-resiliency b86b1ec0dd4209a588dc1285cdd471e73525c0b3)
 git_clone(https://github.com/eapache/queue v1.0.2)
-git_clone_to_path(https://github.com/rafrombrc/sarama f742e1e20b15b31320e0b6ff2f995bc5f0482fed github.com/Shopify/sarama)
-git_clone(https://github.com/davecgh/go-spew 2df174808ee097f90d259e432cc04442cf60be21)
+git_clone(https://github.com/Shopify/sarama 38d579a708d2f87dd4e35342241048e361d1e66a)
+git_clone(https://github.com/klauspost/crc32 19b0b332c9e4516a6370a0456e6182c3b5036720)
+git_clone(https://github.com/davecgh/go-spew 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d)
 
 add_dependencies(sarama snappy)
 


### PR DESCRIPTION
I hit a bug with pulling data out of my kafka topic: the input plugin was always stopping at the same offset and getting stuck in a timeout loop. I was able to reproduce the bug with a standalone application and showed upgrading sarama fixed the data stream. Now updating heka so I can get this fix in to my prod environment.
